### PR TITLE
일정 추가/수정 분기 처리

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/entity/Schedule.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/entity/Schedule.kt
@@ -23,8 +23,16 @@ data class Schedule(
     val name: String,
     val startDate: Date,
     val endDate: Date,
-    val notification: Date?,
+    val notificationType: NotificationType,
     val memo: String,
     // TODO <Library>.ScheduleColorType
     val color: Int
-)
+) {
+
+    enum class NotificationType {
+        NONE,
+        TEN_MINUTES_AGO,
+        A_HOUR_AGO,
+        A_DAY_AGO
+    }
+}

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
@@ -16,7 +16,7 @@ class DeleteScheduleDialog : DialogFragment() {
         .setTitle(R.string.delete_schedule_dialog_title)
         .setMessage(R.string.delete_schedule_dialog_message)
         .setPositiveButton(R.string.delete) { _, _ ->
-            viewModel
+            // TODO: 2021-11-04 일정 삭제 요청
         }
         .create()
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
@@ -13,9 +13,9 @@ class DeleteScheduleDialog : DialogFragment() {
     private val viewModel: SaveScheduleViewModel by navGraphViewModels(R.id.saveScheduleFragment)
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog = AlertDialog.Builder(requireContext())
-        .setTitle(R.string.delete_schedule_dialog_title)
-        .setMessage(R.string.delete_schedule_dialog_message)
-        .setPositiveButton(R.string.delete) { _, _ ->
+        .setTitle(R.string.deleteScheduleDialog_title)
+        .setMessage(R.string.deleteScheduleDialog_message)
+        .setPositiveButton(R.string.menuSaveScheduleToolbar_delete) { _, _ ->
             // TODO: 2021-11-04 일정 삭제 요청
         }
         .create()

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
@@ -1,0 +1,22 @@
+package com.drunkenboys.calendarun.ui.saveschedule
+
+import android.app.AlertDialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import androidx.navigation.navGraphViewModels
+import com.drunkenboys.calendarun.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class DeleteScheduleDialog : DialogFragment() {
+
+    private val viewModel: SaveScheduleViewModel by navGraphViewModels(R.id.saveScheduleFragment)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog = AlertDialog.Builder(requireContext())
+        .setTitle(R.string.delete_schedule_dialog_title)
+        .setMessage(R.string.delete_schedule_dialog_message)
+        .setPositiveButton(R.string.delete) { _, _ ->
+            viewModel
+        }
+        .create()
+}

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -90,7 +90,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     private suspend fun pickDateInMillis() = suspendCancellableCoroutine<Long?> { cont ->
         // TODO: 2021-11-03 picker 생성을 util 패키지로 분리 고려
         val datePicker = MaterialDatePicker.Builder.datePicker()
-            .setTitleText(getString(R.string.pick_date))
+            .setTitleText(getString(R.string.saveSchedule_pickDate))
             .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
             .build()
         datePicker.apply {
@@ -109,7 +109,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
             .setTimeFormat(TimeFormat.CLOCK_12H)
             .setHour(12)
             .setMinute(0)
-            .setTitleText(R.string.pick_time)
+            .setTitleText(R.string.saveSchedule_pickTime)
             .build()
         timePicker.apply {
             addOnPositiveButtonClickListener { cont.resume(timePicker.hour to timePicker.minute) }
@@ -122,7 +122,8 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     }
 
     private fun initTvNotification() {
-        val dropDownAdapter = ArrayAdapter.createFromResource(requireContext(), R.array.notification_type, R.layout.item_drop_down_list)
+        val dropDownAdapter =
+            ArrayAdapter.createFromResource(requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list)
         val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
             anchorView = binding.tvSaveScheduleNotification
             setAdapter(dropDownAdapter)
@@ -140,10 +141,10 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     private fun observeNotification() {
         viewModel.notificationType.observe(viewLifecycleOwner) { type ->
             binding.tvSaveScheduleNotification.text = when (type) {
-                Schedule.NotificationType.NONE -> getString(R.string.notification_none)
-                Schedule.NotificationType.TEN_MINUTES_AGO -> getString(R.string.notification_ten_minutes_ago)
-                Schedule.NotificationType.A_HOUR_AGO -> getString(R.string.notification_a_hour_ago)
-                Schedule.NotificationType.A_DAY_AGO -> getString(R.string.notification_a_day_ago)
+                Schedule.NotificationType.NONE -> getString(R.string.saveSchedule_notificationNone)
+                Schedule.NotificationType.TEN_MINUTES_AGO -> getString(R.string.saveSchedule_notificationTenMinutesAgo)
+                Schedule.NotificationType.A_HOUR_AGO -> getString(R.string.saveSchedule_notificationAHourAgo)
+                Schedule.NotificationType.A_DAY_AGO -> getString(R.string.saveSchedule_notificationADayAgo)
                 null -> ""
             }
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -38,16 +38,14 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
 
-        init()
-        viewModel.init(args.scheduleId, args.calendarId, args.calendarName, args.behaviorType)
-        observeNotification()
-        observeTagColor()
-    }
-
-    private fun init() {
         initToolbar()
         initTimePicker()
         initTvNotification()
+
+        observeNotification()
+        observeTagColor()
+
+        viewModel.init(args)
     }
 
     private fun initToolbar() = with(binding) {
@@ -60,10 +58,11 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         }
         toolbarSaveSchedule.setOnMenuItemClickListener { item ->
             if (item.itemId == R.id.menu_delete_schedule) {
-                DeleteScheduleDialog().show(parentFragmentManager, DeleteScheduleDialog::class.simpleName)
+                navController.navigate(SaveScheduleFragmentDirections.actionSaveScheduleFragmentToDeleteScheduleDialog())
                 true
-            } else
+            } else {
                 false
+            }
         }
 
         val appBarConfig = AppBarConfiguration(navController.graph)

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -39,6 +39,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         binding.viewModel = viewModel
 
         init()
+        viewModel.init(args.scheduleId, args.calendarId, args.calendarName, args.behaviorType)
         observeNotification()
         observeTagColor()
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -8,9 +8,14 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupWithNavController
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.FragmentSaveScheduleBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
+import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
 import com.drunkenboys.calendarun.ui.saveschedule.model.ScheduleNotificationType
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
@@ -26,18 +31,42 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
 
     private val viewModel: SaveScheduleViewModel by viewModels()
 
+    private val navController by lazy { findNavController() }
+    private val args: SaveScheduleFragmentArgs by navArgs()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
 
-        initViews()
+        init()
         observeNotification()
         observeTagColor()
     }
 
-    private fun initViews() {
+    private fun init() {
+        initToolbar()
         initTimePicker()
         initTvNotification()
+    }
+
+    private fun initToolbar() = with(binding) {
+        when (args.behaviorType) {
+            BehaviorType.INSERT -> toolbarSaveSchedule.title = "일정 추가"
+            BehaviorType.UPDATE -> {
+                toolbarSaveSchedule.title = "일정 수정"
+                toolbarSaveSchedule.inflateMenu(R.menu.menu_save_schedule_toolbar)
+            }
+        }
+        toolbarSaveSchedule.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.menu_delete_schedule) {
+                DeleteScheduleDialog().show(parentFragmentManager, DeleteScheduleDialog::class.simpleName)
+                true
+            } else
+                false
+        }
+
+        val appBarConfig = AppBarConfiguration(navController.graph)
+        toolbarSaveSchedule.setupWithNavController(navController, appBarConfig)
     }
 
     private fun initTimePicker() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -13,10 +13,10 @@ import androidx.navigation.fragment.navArgs
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.drunkenboys.calendarun.R
+import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.databinding.FragmentSaveScheduleBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
-import com.drunkenboys.calendarun.ui.saveschedule.model.ScheduleNotificationType
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
@@ -128,7 +128,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
             anchorView = binding.tvSaveScheduleNotification
             setAdapter(dropDownAdapter)
             setOnItemClickListener { _, _, position, _ ->
-                viewModel.notification.value = ScheduleNotificationType.values()[position]
+                viewModel.notificationType.value = Schedule.NotificationType.values()[position]
                 dismiss()
             }
         }
@@ -139,12 +139,12 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     }
 
     private fun observeNotification() {
-        viewModel.notification.observe(viewLifecycleOwner) { type ->
+        viewModel.notificationType.observe(viewLifecycleOwner) { type ->
             binding.tvSaveScheduleNotification.text = when (type) {
-                ScheduleNotificationType.NONE -> getString(R.string.notification_none)
-                ScheduleNotificationType.TEN_MINUTES_AGO -> getString(R.string.notification_ten_minutes_ago)
-                ScheduleNotificationType.A_HOUR_AGO -> getString(R.string.notification_a_hour_ago)
-                ScheduleNotificationType.A_DAY_AGO -> getString(R.string.notification_a_day_ago)
+                Schedule.NotificationType.NONE -> getString(R.string.notification_none)
+                Schedule.NotificationType.TEN_MINUTES_AGO -> getString(R.string.notification_ten_minutes_ago)
+                Schedule.NotificationType.A_HOUR_AGO -> getString(R.string.notification_a_hour_ago)
+                Schedule.NotificationType.A_DAY_AGO -> getString(R.string.notification_a_day_ago)
                 null -> ""
             }
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -29,14 +29,14 @@ import kotlin.coroutines.resume
 @AndroidEntryPoint
 class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.fragment_save_schedule) {
 
-    private val viewModel: SaveScheduleViewModel by viewModels()
+    private val saveScheduleViewModel: SaveScheduleViewModel by viewModels()
 
     private val navController by lazy { findNavController() }
     private val args: SaveScheduleFragmentArgs by navArgs()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.viewModel = viewModel
+        binding.viewModel = saveScheduleViewModel
 
         initToolbar()
         initTimePicker()
@@ -45,7 +45,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         observeNotification()
         observeTagColor()
 
-        viewModel.init(args)
+        saveScheduleViewModel.init(args)
     }
 
     private fun initToolbar() = with(binding) {
@@ -70,8 +70,8 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     }
 
     private fun initTimePicker() {
-        binding.tvSaveScheduleScheduleStartInput.setOnClickListener { selectTime(viewModel.startDate) }
-        binding.tvSaveScheduleScheduleEndInput.setOnClickListener { selectTime(viewModel.endDate) }
+        binding.tvSaveScheduleScheduleStartInput.setOnClickListener { selectTime(saveScheduleViewModel.startDate) }
+        binding.tvSaveScheduleScheduleEndInput.setOnClickListener { selectTime(saveScheduleViewModel.endDate) }
     }
 
     private fun selectTime(liveData: MutableLiveData<Date>) {
@@ -128,7 +128,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
             anchorView = binding.tvSaveScheduleNotification
             setAdapter(dropDownAdapter)
             setOnItemClickListener { _, _, position, _ ->
-                viewModel.notificationType.value = Schedule.NotificationType.values()[position]
+                saveScheduleViewModel.notificationType.value = Schedule.NotificationType.values()[position]
                 dismiss()
             }
         }
@@ -139,7 +139,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     }
 
     private fun observeNotification() {
-        viewModel.notificationType.observe(viewLifecycleOwner) { type ->
+        saveScheduleViewModel.notificationType.observe(viewLifecycleOwner) { type ->
             binding.tvSaveScheduleNotification.text = when (type) {
                 Schedule.NotificationType.NONE -> getString(R.string.saveSchedule_notificationNone)
                 Schedule.NotificationType.TEN_MINUTES_AGO -> getString(R.string.saveSchedule_notificationTenMinutesAgo)
@@ -151,7 +151,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     }
 
     private fun observeTagColor() {
-        viewModel.tagColor.observe(viewLifecycleOwner) { colorRes ->
+        saveScheduleViewModel.tagColor.observe(viewLifecycleOwner) { colorRes ->
             binding.viewSaveScheduleTagColor.backgroundTintList = ContextCompat.getColorStateList(requireContext(), colorRes)
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -8,6 +8,7 @@ import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
+import com.drunkenboys.calendarun.util.SingleLiveEvent
 import com.drunkenboys.calendarun.util.getOrThrow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -40,14 +41,14 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
     private val _tagColor = MutableLiveData(R.color.black)
     val tagColor: LiveData<Int> = _tagColor
 
-    private val _saveScheduleEvent = MutableLiveData<Unit>()
+    private val _saveScheduleEvent = SingleLiveEvent<Unit>()
     val saveScheduleEvent: LiveData<Unit> = _saveScheduleEvent
 
-    fun init(scheduleId: Int, calendarId: Int, calendarName: String, behaviorType: BehaviorType) {
-        this.scheduleId = scheduleId
-        this.calendarId = calendarId
-        _calendarName.value = calendarName
-        this.behaviorType = behaviorType
+    fun init(args: SaveScheduleFragmentArgs) {
+        this.scheduleId = args.scheduleId
+        this.calendarId = args.calendarId
+        _calendarName.value = args.calendarName
+        this.behaviorType = args.behaviorType
 
         if (behaviorType == BehaviorType.UPDATE) initData()
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -44,11 +44,29 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
     private val _saveScheduleEvent = MutableLiveData<Unit>()
     val saveScheduleEvent: LiveData<Unit> = _saveScheduleEvent
 
-    fun init(scheduleId: Int = 0, calendarId: Int, calendarName: String, behaviorType: BehaviorType) {
+    fun init(scheduleId: Int, calendarId: Int, calendarName: String, behaviorType: BehaviorType) {
         this.scheduleId = scheduleId
         this.calendarId = calendarId
         _calendarName.value = calendarName
         this.behaviorType = behaviorType
+
+        if (behaviorType == BehaviorType.UPDATE) initData()
+    }
+
+    private fun initData() {
+        val scheduleId = scheduleId ?: return
+        if (scheduleId < 0) return
+
+        viewModelScope.launch {
+            val schedule = scheduleDataSource.fetchSchedule(scheduleId)
+
+            title.value = schedule.name
+            startDate.value = schedule.startDate
+            endDate.value = schedule.endDate
+            memo.value = schedule.memo
+//            notification = schedule.notification
+            _tagColor.value = schedule.color
+        }
     }
 
     fun Date.toFormatString(): String {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -8,7 +8,6 @@ import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
-import com.drunkenboys.calendarun.ui.saveschedule.model.ScheduleNotificationType
 import com.drunkenboys.calendarun.util.getOrThrow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -36,7 +35,7 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
     private val _calendarName = MutableLiveData("test")
     val calendarName: LiveData<String> = _calendarName
 
-    val notification = MutableLiveData(ScheduleNotificationType.TEN_MINUTES_AGO)
+    val notificationType = MutableLiveData(Schedule.NotificationType.TEN_MINUTES_AGO)
 
     private val _tagColor = MutableLiveData(R.color.black)
     val tagColor: LiveData<Int> = _tagColor
@@ -64,7 +63,7 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
             startDate.value = schedule.startDate
             endDate.value = schedule.endDate
             memo.value = schedule.memo
-//            notification = schedule.notification
+            notificationType.value = schedule.notificationType
             _tagColor.value = schedule.color
         }
     }
@@ -111,7 +110,7 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
         name = title.getOrThrow(),
         startDate = startDate.getOrThrow(),
         endDate = endDate.getOrThrow(),
-        notification = getNotificationDate(),
+        notificationType = notificationType.getOrThrow(),
         memo = memo.getOrThrow(),
         color = tagColor.getOrThrow()
     )
@@ -120,11 +119,11 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
         val calendar = Calendar.getInstance()
         calendar.time = startDate.getOrThrow()
 
-        when (notification.value) {
-            ScheduleNotificationType.NONE -> return null
-            ScheduleNotificationType.TEN_MINUTES_AGO -> calendar.add(Calendar.MINUTE, -10)
-            ScheduleNotificationType.A_HOUR_AGO -> calendar.add(Calendar.HOUR_OF_DAY, -1)
-            ScheduleNotificationType.A_DAY_AGO -> calendar.add(Calendar.DAY_OF_YEAR, -1)
+        when (notificationType.value) {
+            Schedule.NotificationType.NONE -> return null
+            Schedule.NotificationType.TEN_MINUTES_AGO -> calendar.add(Calendar.MINUTE, -10)
+            Schedule.NotificationType.A_HOUR_AGO -> calendar.add(Calendar.HOUR_OF_DAY, -1)
+            Schedule.NotificationType.A_DAY_AGO -> calendar.add(Calendar.DAY_OF_YEAR, -1)
         }
 
         return calendar.time

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/model/ScheduleNotificationType.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/model/ScheduleNotificationType.kt
@@ -1,8 +1,0 @@
-package com.drunkenboys.calendarun.ui.saveschedule.model
-
-enum class ScheduleNotificationType {
-    NONE,
-    TEN_MINUTES_AGO,
-    A_HOUR_AGO,
-    A_DAY_AGO
-}

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z" />
+</vector>

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -45,7 +45,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="@null"
-                    android:hint="@string/schedule_title"
+                    android:hint="@string/saveSchedule_title"
                     android:importantForAutofill="no"
                     android:inputType="text"
                     android:paddingVertical="16dp"
@@ -71,7 +71,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:text="@string/start"
+                    android:text="@string/saveSchedule_start"
                     app:layout_constraintBottom_toTopOf="@id/tv_saveSchedule_scheduleEnd"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/divider_saveSchedule_titleBottom" />
@@ -81,7 +81,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
-                    android:text="@string/end"
+                    android:text="@string/saveSchedule_end"
                     app:layout_constraintBottom_toTopOf="@id/divider_saveSchedule_timeBottom"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_saveSchedule_scheduleStart" />
@@ -121,7 +121,7 @@
                     android:layout_width="0dp"
                     android:layout_height="1dp"
                     android:layout_marginTop="100dp"
-                    android:background="@color/color_cccccc"
+                    android:background="@color/divider"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/divider_saveSchedule_titleBottom" />
@@ -133,7 +133,7 @@
                     android:background="@null"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
-                    android:hint="@string/memo"
+                    android:hint="@string/saveSchedule_memo"
                     android:importantForAutofill="no"
                     android:inputType="text"
                     android:paddingVertical="16dp"
@@ -150,7 +150,7 @@
                     android:id="@+id/divider_saveSchedule_memoBottom"
                     android:layout_width="0dp"
                     android:layout_height="1dp"
-                    android:background="@color/color_cccccc"
+                    android:background="@color/divider"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/et_saveSchedule_memo" />
@@ -168,13 +168,13 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/divider_saveSchedule_memoBottom"
-                    tools:text="@string/calendar_name" />
+                    tools:text="@string/saveSchedule_calendarName" />
 
                 <View
                     android:id="@+id/divider_saveSchedule_calendarNameBottom"
                     android:layout_width="0dp"
                     android:layout_height="1dp"
-                    android:background="@color/color_cccccc"
+                    android:background="@color/divider"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_saveSchedule_calendarName" />
@@ -191,13 +191,13 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/divider_saveSchedule_calendarNameBottom"
-                    tools:text="@string/notification_ten_minutes_ago" />
+                    tools:text="@string/saveSchedule_notificationTenMinutesAgo" />
 
                 <View
                     android:id="@+id/divider_saveSchedule_notificationBottom"
                     android:layout_width="0dp"
                     android:layout_height="1dp"
-                    android:background="@color/color_cccccc"
+                    android:background="@color/divider"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_saveSchedule_notification" />
@@ -209,7 +209,7 @@
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
                     android:paddingVertical="16dp"
-                    android:text="@string/tag_color"
+                    android:text="@string/saveSchedule_tagColor"
                     android:textColor="@color/black"
                     app:drawableStartCompat="@drawable/ic_palette"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -235,7 +235,7 @@
             android:layout_height="60dp"
             android:layout_marginHorizontal="4dp"
             android:onClick="@{() -> viewModel.saveSchedule()}"
-            android:text="@string/save"
+            android:text="@string/saveSchedule_save"
             app:backgroundTint="@color/black" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -22,6 +22,7 @@
             android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar_saveSchedule"
                 android:layout_width="match_parent"
                 android:layout_height="?actionBarSize"
                 app:titleTextColor="@color/white"

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".ui.saveschedule.SaveScheduleFragment">
 
     <data>
 

--- a/app/src/main/res/menu/menu_save_schedule_toolbar.xml
+++ b/app/src/main/res/menu/menu_save_schedule_toolbar.xml
@@ -4,6 +4,6 @@
     <item
         android:id="@+id/menu_delete_schedule"
         android:icon="@drawable/ic_delete"
-        android:title="@string/delete"
+        android:title="@string/menuSaveScheduleToolbar_delete"
         app:showAsAction="always" />
 </menu>

--- a/app/src/main/res/menu/menu_save_schedule_toolbar.xml
+++ b/app/src/main/res/menu/menu_save_schedule_toolbar.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_delete_schedule"
+        android:icon="@drawable/ic_delete"
+        android:title="@string/delete"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/navigation/nav_temp.xml
+++ b/app/src/main/res/navigation/nav_temp.xml
@@ -10,6 +10,10 @@
         android:name="com.drunkenboys.calendarun.ui.saveschedule.SaveScheduleFragment"
         tools:layout="@layout/fragment_save_schedule">
         <argument
+            android:name="scheduleId"
+            android:defaultValue="-1"
+            app:argType="integer" />
+        <argument
             android:name="calendarId"
             android:defaultValue="-1"
             app:argType="integer" />

--- a/app/src/main/res/navigation/nav_temp.xml
+++ b/app/src/main/res/navigation/nav_temp.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_temp"
+    app:startDestination="@id/saveScheduleFragment">
+
+    <fragment
+        android:id="@+id/saveScheduleFragment"
+        android:name="com.drunkenboys.calendarun.ui.saveschedule.SaveScheduleFragment"
+        tools:layout="@layout/fragment_save_schedule">
+        <argument
+            android:name="calendarId"
+            android:defaultValue="-1"
+            app:argType="integer" />
+        <argument
+            android:name="calendarName"
+            android:defaultValue="temp"
+            app:argType="string" />
+        <argument
+            android:name="behaviorType"
+            android:defaultValue="INSERT"
+            app:argType="com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType" />
+    </fragment>
+</navigation>

--- a/app/src/main/res/navigation/nav_temp.xml
+++ b/app/src/main/res/navigation/nav_temp.xml
@@ -25,5 +25,12 @@
             android:name="behaviorType"
             android:defaultValue="INSERT"
             app:argType="com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType" />
+        <action
+            android:id="@+id/action_saveScheduleFragment_to_deleteScheduleDialog"
+            app:destination="@id/deleteScheduleDialog" />
     </fragment>
+    <dialog
+        android:id="@+id/deleteScheduleDialog"
+        android:name="com.drunkenboys.calendarun.ui.saveschedule.DeleteScheduleDialog"
+        android:label="DeleteScheduleDialog" />
 </navigation>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="notification_type">
-        <item>@string/notification_none</item>
-        <item>@string/notification_ten_minutes_ago</item>
-        <item>@string/notification_a_hour_ago</item>
-        <item>@string/notification_a_day_ago</item>
+    <string-array name="saveSchedule_notificationType">
+        <item>@string/saveSchedule_notificationNone</item>
+        <item>@string/saveSchedule_notificationTenMinutesAgo</item>
+        <item>@string/saveSchedule_notificationAHourAgo</item>
+        <item>@string/saveSchedule_notificationADayAgo</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,5 +8,5 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
-    <color name="color_cccccc">#cccccc</color>
+    <color name="divider">#cccccc</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,23 +12,24 @@
     <string name="check_point_name">이름</string>
     <string name="check_point_date">날짜</string>
 
-    <string name="schedule_title">제목</string>
-    <string name="start">시작</string>
-    <string name="end">종료</string>
-    <string name="memo">메모</string>
-    <string name="calendar_name">캘린더 명</string>
-    <string name="tag_color">태그 색상</string>
-    <string name="save">저장</string>
+    <string name="saveSchedule_title">제목</string>
+    <string name="saveSchedule_start">시작</string>
+    <string name="saveSchedule_end">종료</string>
+    <string name="saveSchedule_memo">메모</string>
+    <string name="saveSchedule_calendarName">캘린더 명</string>
+    <string name="saveSchedule_tagColor">태그 색상</string>
+    <string name="saveSchedule_save">저장</string>
 
-    <string name="notification_none">없음</string>
-    <string name="notification_ten_minutes_ago">10분 전 알림</string>
-    <string name="notification_a_hour_ago">한 시간 전 알림</string>
-    <string name="notification_a_day_ago">하루 전 알림</string>
+    <string name="saveSchedule_notificationNone">없음</string>
+    <string name="saveSchedule_notificationTenMinutesAgo">10분 전 알림</string>
+    <string name="saveSchedule_notificationAHourAgo">한 시간 전 알림</string>
+    <string name="saveSchedule_notificationADayAgo">하루 전 알림</string>
 
-    <string name="pick_date">요일 선택</string>
-    <string name="pick_time">시간 선택</string>
+    <string name="saveSchedule_pickDate">요일 선택</string>
+    <string name="saveSchedule_pickTime">시간 선택</string>
 
-    <string name="delete">삭제</string>
-    <string name="delete_schedule_dialog_title">일정 삭제</string>
-    <string name="delete_schedule_dialog_message">일정을 삭제하면 복구할 수 없습니다.\n삭제하시겠습니까?</string>
+    <string name="menuSaveScheduleToolbar_delete">삭제</string>
+
+    <string name="deleteScheduleDialog_title">일정 삭제</string>
+    <string name="deleteScheduleDialog_message">일정을 삭제하면 복구할 수 없습니다.\n삭제하시겠습니까?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,8 @@
 
     <string name="pick_date">요일 선택</string>
     <string name="pick_time">시간 선택</string>
+
+    <string name="delete">삭제</string>
+    <string name="delete_schedule_dialog_title">일정 삭제</string>
+    <string name="delete_schedule_dialog_message">일정을 삭제하면 복구할 수 없습니다.\n삭제하시겠습니까?</string>
 </resources>

--- a/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.drunkenboys.calendarun.ui.saveschedule
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.FakeScheduleLocalDataSource
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
@@ -8,7 +9,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.test.*
-import org.junit.*
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.*
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -43,7 +49,24 @@ class SaveScheduleViewModelTest {
 
         viewModel.init(1, 2, calendarName, BehaviorType.INSERT)
 
-        Assert.assertEquals(calendarName, viewModel.calendarName.value)
+        assertEquals(calendarName, viewModel.calendarName.value)
+    }
+
+    @Test
+    fun `일정_수정_시_뷰모델_초기화_테스트`() = testScope.runBlockingTest {
+        val calendarName = "내 캘린더"
+        val startDate = Date()
+        val endDate = Date()
+        dataSource.insertSchedule(Schedule(0, 0, "test", startDate, endDate, Schedule.NotificationType.A_HOUR_AGO, "memo", 0))
+
+        viewModel.init(0, 0, calendarName, BehaviorType.UPDATE)
+
+        assertEquals("test", viewModel.title.value)
+        assertEquals(startDate, viewModel.startDate.value)
+        assertEquals(endDate, viewModel.endDate.value)
+        assertEquals(Schedule.NotificationType.A_HOUR_AGO, viewModel.notificationType.value)
+        assertEquals("memo", viewModel.memo.value)
+        assertEquals(0, viewModel.tagColor.value)
     }
 
     @Test
@@ -53,7 +76,7 @@ class SaveScheduleViewModelTest {
         viewModel.init(1, 2, calendarName, BehaviorType.INSERT)
         viewModel.saveSchedule()
 
-        Assert.assertEquals(null, viewModel.saveScheduleEvent.value)
+        assertEquals(null, viewModel.saveScheduleEvent.value)
     }
 
     @Test
@@ -64,6 +87,6 @@ class SaveScheduleViewModelTest {
         viewModel.title.value = "내 일정"
         viewModel.saveSchedule()
 
-        Assert.assertEquals(Unit, viewModel.saveScheduleEvent.value)
+        assertEquals(Unit, viewModel.saveScheduleEvent.value)
     }
 }

--- a/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
@@ -47,7 +47,7 @@ class SaveScheduleViewModelTest {
     fun `뷰모델_초기화_테스트`() {
         val calendarName = "내 캘린더"
 
-        viewModel.init(1, 2, calendarName, BehaviorType.INSERT)
+        viewModel.init(SaveScheduleFragmentArgs(1, 2, calendarName, BehaviorType.INSERT))
 
         assertEquals(calendarName, viewModel.calendarName.value)
     }
@@ -59,7 +59,7 @@ class SaveScheduleViewModelTest {
         val endDate = Date()
         dataSource.insertSchedule(Schedule(0, 0, "test", startDate, endDate, Schedule.NotificationType.A_HOUR_AGO, "memo", 0))
 
-        viewModel.init(0, 0, calendarName, BehaviorType.UPDATE)
+        viewModel.init(SaveScheduleFragmentArgs(0, 0, calendarName, BehaviorType.UPDATE))
 
         assertEquals("test", viewModel.title.value)
         assertEquals(startDate, viewModel.startDate.value)
@@ -73,7 +73,7 @@ class SaveScheduleViewModelTest {
     fun `제목_미입력_시_저장_테스트`() = testScope.runBlockingTest {
         val calendarName = "내 캘린더"
 
-        viewModel.init(1, 2, calendarName, BehaviorType.INSERT)
+        viewModel.init(SaveScheduleFragmentArgs(1, 2, calendarName, BehaviorType.INSERT))
         viewModel.saveSchedule()
 
         assertEquals(null, viewModel.saveScheduleEvent.value)
@@ -83,7 +83,7 @@ class SaveScheduleViewModelTest {
     fun `정상_입력_시_저장_테스트`() {
         val calendarName = "내 캘린더"
 
-        viewModel.init(1, 2, calendarName, BehaviorType.INSERT)
+        viewModel.init(SaveScheduleFragmentArgs(1, 2, calendarName, BehaviorType.INSERT))
         viewModel.title.value = "내 일정"
         viewModel.saveSchedule()
 


### PR DESCRIPTION
## what is this pr
- 추가/수정 동작에 따라 툴바 구성(제목, 백버튼, 메뉴) 변경
- 일정 수정 시 수정할 일정의 데이터로 뷰모델의 프로퍼티 초기화

Resolve: #19 

## Changes
내비게이션 그래프는 임시로 SaveScheduleFragment만 추가하여 동작을 테스트 함.

Schedule entity에서 notification 타입을 Date?에서 enum class로 변경되었는데, 일정 수정 시 기존의 일정 데이터의 
notification Date 객체로부터 staetDate의 차이를 비교하여 ScheduleNotificationType을 얻는 과정이 번잡하게 느껴져 변경하였음.

## testchecklist
- 수정 동작 시 기존의 일정 데이터로 뷰모델을 초기화하는 로직 테스트
