### PR TITLE
일정 삭제 기능 구현

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
@@ -1,9 +1,6 @@
 package com.drunkenboys.calendarun.data.schedule.local
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.Query
-import androidx.room.Update
+import androidx.room.*
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 
 @Dao
@@ -20,5 +17,8 @@ interface ScheduleDao {
 
     @Update
     suspend fun updateSchedule(schedule: Schedule)
+
+    @Delete
+    suspend fun deleteSchedule(schedule: Schedule)
 
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
@@ -12,4 +12,6 @@ interface ScheduleLocalDataSource {
 
     suspend fun updateSchedule(schedule: Schedule)
 
+    suspend fun deleteSchedule(schedule: Schedule)
+
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
@@ -28,4 +28,8 @@ class ScheduleLocalDataSourceImpl @Inject constructor(
     override suspend fun updateSchedule(schedule: Schedule) = withContext(dispatcher) {
         scheduleDao.updateSchedule(schedule)
     }
+
+    override suspend fun deleteSchedule(schedule: Schedule) = withContext(dispatcher) {
+        scheduleDao.deleteSchedule(schedule)
+    }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/DeleteScheduleDialog.kt
@@ -10,13 +10,15 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class DeleteScheduleDialog : DialogFragment() {
 
-    private val viewModel: SaveScheduleViewModel by navGraphViewModels(R.id.saveScheduleFragment)
+    private val saveScheduleViewModel: SaveScheduleViewModel
+            by navGraphViewModels(R.id.saveScheduleFragment) { defaultViewModelProviderFactory }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog = AlertDialog.Builder(requireContext())
         .setTitle(R.string.deleteScheduleDialog_title)
         .setMessage(R.string.deleteScheduleDialog_message)
         .setPositiveButton(R.string.menuSaveScheduleToolbar_delete) { _, _ ->
-            // TODO: 2021-11-04 일정 삭제 요청
+            saveScheduleViewModel.deleteSchedule()
         }
+        .setNegativeButton(R.string.deleteScheduleDialog_cancel) { _, _ -> }
         .create()
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -40,9 +40,8 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         binding.viewModel = saveScheduleViewModel
 
         initToolbar()
-        initTvNotification()
-
         observePickDateTimeEvent()
+        observePickNotificationTypeEvent()
         observeNotification()
         observeTagColor()
 
@@ -70,23 +69,6 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         toolbarSaveSchedule.setupWithNavController(navController, appBarConfig)
     }
 
-    private fun initTvNotification() {
-        val dropDownAdapter =
-            ArrayAdapter.createFromResource(requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list)
-        val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
-            anchorView = binding.tvSaveScheduleNotification
-            setAdapter(dropDownAdapter)
-            setOnItemClickListener { _, _, position, _ ->
-                saveScheduleViewModel.notificationType.value = Schedule.NotificationType.values()[position]
-                dismiss()
-            }
-        }
-
-        binding.tvSaveScheduleNotification.setOnClickListener {
-            listPopupWindow.show()
-        }
-    }
-
     private fun observePickDateTimeEvent() {
         saveScheduleViewModel.pickDateTimeEvent.observe(viewLifecycleOwner) { dateType ->
             dateType ?: return@observe
@@ -103,6 +85,26 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
                     DateType.START -> saveScheduleViewModel.startDate.value = calendar.time
                     DateType.END -> saveScheduleViewModel.endDate.value = calendar.time
                 }
+            }
+        }
+    }
+
+    private fun observePickNotificationTypeEvent() {
+        saveScheduleViewModel.pickNotificationTypeEvent.observe(viewLifecycleOwner) {
+            val dropDownAdapter = ArrayAdapter.createFromResource(
+                requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list
+            )
+            val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
+                anchorView = binding.tvSaveScheduleNotification
+                setAdapter(dropDownAdapter)
+                setOnItemClickListener { _, _, position, _ ->
+                    saveScheduleViewModel.notificationType.value = Schedule.NotificationType.values()[position]
+                    dismiss()
+                }
+            }
+
+            binding.tvSaveScheduleNotification.setOnClickListener {
+                listPopupWindow.show()
             }
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.ListPopupWindow
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -17,6 +16,7 @@ import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.databinding.FragmentSaveScheduleBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
+import com.drunkenboys.calendarun.ui.saveschedule.model.DateType
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
@@ -40,9 +40,9 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         binding.viewModel = saveScheduleViewModel
 
         initToolbar()
-        initTimePicker()
         initTvNotification()
 
+        observePickDateTimeEvent()
         observeNotification()
         observeTagColor()
 
@@ -70,21 +70,40 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         toolbarSaveSchedule.setupWithNavController(navController, appBarConfig)
     }
 
-    private fun initTimePicker() {
-        binding.tvSaveScheduleScheduleStartInput.setOnClickListener { selectTime(saveScheduleViewModel.startDate) }
-        binding.tvSaveScheduleScheduleEndInput.setOnClickListener { selectTime(saveScheduleViewModel.endDate) }
+    private fun initTvNotification() {
+        val dropDownAdapter =
+            ArrayAdapter.createFromResource(requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list)
+        val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
+            anchorView = binding.tvSaveScheduleNotification
+            setAdapter(dropDownAdapter)
+            setOnItemClickListener { _, _, position, _ ->
+                saveScheduleViewModel.notificationType.value = Schedule.NotificationType.values()[position]
+                dismiss()
+            }
+        }
+
+        binding.tvSaveScheduleNotification.setOnClickListener {
+            listPopupWindow.show()
+        }
     }
 
-    private fun selectTime(liveData: MutableLiveData<Date>) {
-        lifecycleScope.launch {
-            val calendar = Calendar.getInstance()
+    private fun observePickDateTimeEvent() {
+        saveScheduleViewModel.pickDateTimeEvent.observe(viewLifecycleOwner) { dateType ->
+            dateType ?: return@observe
 
-            calendar.timeInMillis = pickDateInMillis() ?: return@launch
-            val (hour, minute) = pickTime() ?: return@launch
-            calendar.set(Calendar.HOUR_OF_DAY, hour)
-            calendar.set(Calendar.MINUTE, minute)
+            lifecycleScope.launch {
+                val calendar = Calendar.getInstance()
 
-            liveData.value = calendar.time
+                calendar.timeInMillis = pickDateInMillis() ?: return@launch
+                val (hour, minute) = pickTime() ?: return@launch
+                calendar.set(Calendar.HOUR_OF_DAY, hour)
+                calendar.set(Calendar.MINUTE, minute)
+
+                when (dateType) {
+                    DateType.START -> saveScheduleViewModel.startDate.value = calendar.time
+                    DateType.END -> saveScheduleViewModel.endDate.value = calendar.time
+                }
+            }
         }
     }
 
@@ -120,23 +139,6 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         }
 
         timePicker.show(parentFragmentManager, this@SaveScheduleFragment::class.simpleName)
-    }
-
-    private fun initTvNotification() {
-        val dropDownAdapter =
-            ArrayAdapter.createFromResource(requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list)
-        val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
-            anchorView = binding.tvSaveScheduleNotification
-            setAdapter(dropDownAdapter)
-            setOnItemClickListener { _, _, position, _ ->
-                saveScheduleViewModel.notificationType.value = Schedule.NotificationType.values()[position]
-                dismiss()
-            }
-        }
-
-        binding.tvSaveScheduleNotification.setOnClickListener {
-            listPopupWindow.show()
-        }
     }
 
     private fun observeNotification() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -5,11 +5,11 @@ import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.ListPopupWindow
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.navigation.navGraphViewModels
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.drunkenboys.calendarun.R
@@ -29,7 +29,8 @@ import kotlin.coroutines.resume
 @AndroidEntryPoint
 class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.fragment_save_schedule) {
 
-    private val saveScheduleViewModel: SaveScheduleViewModel by viewModels()
+    private val saveScheduleViewModel: SaveScheduleViewModel
+            by navGraphViewModels(R.id.saveScheduleFragment) { defaultViewModelProviderFactory }
 
     private val navController by lazy { findNavController() }
     private val args: SaveScheduleFragmentArgs by navArgs()

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -92,7 +92,9 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     private fun observePickNotificationTypeEvent() {
         saveScheduleViewModel.pickNotificationTypeEvent.observe(viewLifecycleOwner) {
             val dropDownAdapter = ArrayAdapter.createFromResource(
-                requireContext(), R.array.saveSchedule_notificationType, R.layout.item_drop_down_list
+                requireContext(),
+                R.array.saveSchedule_notificationType,
+                R.layout.item_drop_down_list
             )
             val listPopupWindow = ListPopupWindow(requireContext(), null, R.attr.listPopupWindowStyle).apply {
                 anchorView = binding.tvSaveScheduleNotification

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -129,4 +129,16 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
 
         return calendar.time
     }
+
+    fun deleteSchedule() {
+        val scheduleId = scheduleId ?: return
+        if (scheduleId < 0) return
+
+        viewModelScope.launch {
+            val deleteSchedule = scheduleDataSource.fetchSchedule(scheduleId)
+            scheduleDataSource.deleteSchedule(deleteSchedule)
+
+            _saveScheduleEvent.value = Unit
+        }
+    }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -8,6 +8,7 @@ import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
+import com.drunkenboys.calendarun.ui.saveschedule.model.DateType
 import com.drunkenboys.calendarun.util.SingleLiveEvent
 import com.drunkenboys.calendarun.util.getOrThrow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -44,6 +45,9 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
     private val _saveScheduleEvent = SingleLiveEvent<Unit>()
     val saveScheduleEvent: LiveData<Unit> = _saveScheduleEvent
 
+    private val _pickDateTimeEvent = SingleLiveEvent<DateType>()
+    val pickDateTimeEvent: LiveData<DateType> = _pickDateTimeEvent
+
     fun init(args: SaveScheduleFragmentArgs) {
         this.scheduleId = args.scheduleId
         this.calendarId = args.calendarId
@@ -67,6 +71,10 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
             notificationType.value = schedule.notificationType
             _tagColor.value = schedule.color
         }
+    }
+
+    fun emitPickDateTimeEvent(dateType: DateType) {
+        _pickDateTimeEvent.value = dateType
     }
 
     fun Date.toFormatString(): String {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -48,6 +48,9 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
     private val _pickDateTimeEvent = SingleLiveEvent<DateType>()
     val pickDateTimeEvent: LiveData<DateType> = _pickDateTimeEvent
 
+    private val _pickNotificationTypeEvent = SingleLiveEvent<Unit>()
+    val pickNotificationTypeEvent: LiveData<Unit> = _pickNotificationTypeEvent
+
     fun init(args: SaveScheduleFragmentArgs) {
         this.scheduleId = args.scheduleId
         this.calendarId = args.calendarId
@@ -75,6 +78,10 @@ class SaveScheduleViewModel @Inject constructor(private val scheduleDataSource: 
 
     fun emitPickDateTimeEvent(dateType: DateType) {
         _pickDateTimeEvent.value = dateType
+    }
+
+    fun emitPickNotificationTypeEvent() {
+        _pickNotificationTypeEvent.value = Unit
     }
 
     fun Date.toFormatString(): String {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/model/DateType.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/model/DateType.kt
@@ -1,0 +1,6 @@
+package com.drunkenboys.calendarun.ui.saveschedule.model
+
+enum class DateType {
+    START,
+    END
+}

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -189,6 +189,7 @@
                     android:layout_height="wrap_content"
                     android:drawablePadding="8dp"
                     android:gravity="center_vertical"
+                    android:onClick="@{() -> viewModel.emitPickNotificationTypeEvent()}"
                     android:paddingVertical="16dp"
                     android:textColor="@color/black"
                     app:drawableStartCompat="@drawable/ic_notifications"

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -6,6 +6,8 @@
 
     <data>
 
+        <import type="com.drunkenboys.calendarun.ui.saveschedule.model.DateType" />
+
         <variable
             name="viewModel"
             type="com.drunkenboys.calendarun.ui.saveschedule.SaveScheduleViewModel" />
@@ -91,6 +93,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:gravity="end"
+                    android:onClick="@{() -> viewModel.emitPickDateTimeEvent(DateType.START) }"
                     android:paddingVertical="8dp"
                     android:text="@{viewModel.toFormatString(viewModel.startDate)}"
                     android:textColor="@color/black"
@@ -106,6 +109,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:gravity="end"
+                    android:onClick="@{() -> viewModel.emitPickDateTimeEvent(DateType.END) }"
                     android:paddingVertical="8dp"
                     android:text="@{viewModel.toFormatString(viewModel.endDate)}"
                     android:textColor="@color/black"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
 
     <string name="deleteScheduleDialog_title">일정 삭제</string>
     <string name="deleteScheduleDialog_message">일정을 삭제하면 복구할 수 없습니다.\n삭제하시겠습니까?</string>
+    <string name="deleteScheduleDialog_cancel">취소</string>
 </resources>

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
@@ -23,4 +23,8 @@ class FakeScheduleLocalDataSource : ScheduleLocalDataSource {
         database.removeAt(targetIndex)
         database.add(targetIndex, schedule)
     }
+
+    override suspend fun deleteSchedule(schedule: Schedule) {
+        database.remove(schedule)
+    }
 }

--- a/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
@@ -89,4 +89,17 @@ class SaveScheduleViewModelTest {
 
         assertEquals(Unit, viewModel.saveScheduleEvent.value)
     }
+
+    @Test
+    fun `일정_삭제_테스트`() = testScope.runBlockingTest {
+        val calendarName = "내 캘린더"
+        val startDate = Date()
+        val endDate = Date()
+        dataSource.insertSchedule(Schedule(0, 0, "test", startDate, endDate, Schedule.NotificationType.A_HOUR_AGO, "memo", 0))
+        viewModel.init(SaveScheduleFragmentArgs(0, 0, calendarName, BehaviorType.UPDATE))
+        
+        viewModel.deleteSchedule()
+
+        assertEquals(Unit, viewModel.saveScheduleEvent.value)
+    }
 }


### PR DESCRIPTION
## what is this pr
- 수정 모드로 페이지에 진입했을 때 앱 바 메뉴를 통해 일정을 삭제하는 기능 구현.
- 테스트 데이터를 생성 후 실행 시 DB에서 정상적으로 제거되는 것을 확인.
- 현재 추가/수정/삭제에 대한 피드백/내비게이션이 없는데 메인 페이지가 준비되면 토스트와 함께 이전 페이지로 이동할 예정.

  Resolve: #26  

## Changes
- 일정 삭제 쿼리 추가
- 일정 삭제 기능 구현

## screenshot
<img src="https://user-images.githubusercontent.com/52354794/140271763-a27d3672-3e93-4adb-9329-b2e3abcd6788.gif" width="350"/> 

## testchecklist
- 일정 삭제 기능 테스트