### PR TITLE
YearCalendar 성능 개선

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarController.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarController.kt
@@ -1,0 +1,109 @@
+package com.drunkenboys.ckscalendar.yearcalendar
+
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+import com.drunkenboys.ckscalendar.data.CalendarDate
+import com.drunkenboys.ckscalendar.data.CalendarSet
+import com.drunkenboys.ckscalendar.data.DayType
+import com.drunkenboys.ckscalendar.utils.TimeUtils
+import java.time.DayOfWeek
+
+class YearCalendarController {
+
+    fun dayOfWeekConstraints(weekIds: List<String>) = ConstraintSet {
+        val sunday = createRefFor(weekIds[0])
+        val monday = createRefFor(weekIds[1])
+        val tuesday = createRefFor(weekIds[2])
+        val wednesday = createRefFor(weekIds[3])
+        val thursday = createRefFor(weekIds[4])
+        val friday = createRefFor(weekIds[5])
+        val saturday = createRefFor(weekIds[6])
+
+        constrain(sunday) {
+            top.linkTo(parent.top)
+            start.linkTo(parent.start)
+            end.linkTo(monday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(monday) {
+            top.linkTo(parent.top)
+            start.linkTo(sunday.end)
+            end.linkTo(tuesday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(tuesday) {
+            top.linkTo(parent.top)
+            start.linkTo(monday.end)
+            end.linkTo(wednesday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(wednesday) {
+            top.linkTo(parent.top)
+            start.linkTo(tuesday.end)
+            end.linkTo(thursday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(thursday) {
+            top.linkTo(parent.top)
+            start.linkTo(wednesday.end)
+            end.linkTo(friday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(friday) {
+            top.linkTo(parent.top)
+            start.linkTo(thursday.end)
+            end.linkTo(saturday.start)
+            width = Dimension.fillToConstraints
+        }
+
+        constrain(saturday) {
+            top.linkTo(parent.top)
+            start.linkTo(friday.end)
+            end.linkTo(parent.end)
+            width = Dimension.fillToConstraints
+        }
+    }
+
+    fun calendarSetToCalendarDates(month: CalendarSet): List<List<CalendarDate>> {
+        // n주
+        val weekList = mutableListOf<MutableList<CalendarDate>>()
+        var oneDay = month.startDate
+        var paddingPrev = month.startDate
+        var paddingNext = month.endDate
+
+        // 앞쪽 패딩
+        if (paddingPrev.dayOfWeek != DayOfWeek.SUNDAY) weekList.add(mutableListOf())
+        while (paddingPrev.dayOfWeek != DayOfWeek.SUNDAY) {
+            paddingPrev = paddingPrev.minusDays(1)
+            weekList.last().add(CalendarDate(paddingPrev, DayType.PADDING))
+        }
+
+        // n주일 추가
+        repeat(month.startDate.lengthOfMonth()) {
+            // 일요일에는 1주일 갱신
+            if (oneDay.dayOfWeek == DayOfWeek.SUNDAY) weekList.add(mutableListOf())
+
+            // 1주일 추가
+            weekList.last().add(CalendarDate(oneDay, TimeUtils.parseDayWeekToDayType(oneDay.dayOfWeek)))
+
+            oneDay = oneDay.plusDays(1L)
+        }
+
+        // 뒤쪽 패딩
+        while (paddingNext.dayOfWeek != DayOfWeek.SATURDAY) {
+            paddingNext = paddingNext.plusDays(1)
+            weekList.last().add(CalendarDate(paddingNext, DayType.PADDING))
+        }
+
+        return weekList
+    }
+
+    fun isFirstWeek(week: List<CalendarDate>, monthId: Int) = week.any { day ->
+        day.date.dayOfMonth == 1 && monthId == day.date.monthValue
+    }
+}

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarHeader.kt
@@ -1,0 +1,56 @@
+package com.drunkenboys.ckscalendar.yearcalendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.drunkenboys.ckscalendar.R
+import com.drunkenboys.ckscalendar.data.CalendarSet
+
+class YearCalendarHeader {
+
+    private val controller = YearCalendarController()
+
+    @Composable
+    fun WeekHeader() {
+        val weekIds = listOf(
+            stringResource(R.string.sunday),
+            stringResource(R.string.monday),
+            stringResource(R.string.tuesday),
+            stringResource(R.string.wednesday),
+            stringResource(R.string.thursday),
+            stringResource(R.string.friday),
+            stringResource(R.string.saturday)
+        )
+
+        ConstraintLayout(controller.dayOfWeekConstraints(weekIds)) {
+            weekIds.forEach { dayId ->
+                DayOfWeekTextView(dayOfWeek = dayId)
+            }
+        }
+    }
+
+    @Composable
+    private fun DayOfWeekTextView(dayOfWeek: String) {
+        Text(
+            text = dayOfWeek,
+            modifier = Modifier.layoutId(dayOfWeek),
+            textAlign = TextAlign.Center
+        )
+    }
+
+    @Composable
+    fun YearHeader(year: List<CalendarSet>) {
+        Text( //FIXME: background 투명하지 않게 설정
+            text = "${year[0].startDate.year}년",
+            modifier = Modifier.background(color = Color.White).fillMaxWidth(),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.DataBindingUtil
@@ -106,10 +107,12 @@ class YearCalendarView
 
         // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
         rememberCoroutineScope().launch {
+            listState.scrollToItem(index = LAST_YEAR - 1) // preload
             listState.scrollToItem(index = getTodayItemIndex())
         }
     }
 
+    // FIXME: 스케줄 추가하면서 패딩 조정
     @Composable
     private fun DayText(day: CalendarDate) {
         Text(
@@ -120,7 +123,7 @@ class YearCalendarView
                 DayType.SUNDAY -> Color.Red
                 else -> Color.Black
             },
-            modifier = Modifier.layoutId(day.date.toString()),
+            modifier = Modifier.layoutId(day.date.toString()).padding(top = 30.dp),
             textAlign = TextAlign.Center,
         )
     }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #73
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->

- compose를 읽기 힘들것 같아 파일 분리
- 미리 스크롤을 맨 밑으로 이동한 뒤 오늘날짜로 스크롤하는 방법으로 성능 개선

## testchecklist
- 액티비티가 없어 ui 테스트 실패 ㅠㅠ
