### PR TITLE
Year Calendar 클릭 리스너 생성

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -67,7 +68,6 @@ class YearCalendarView
     }
 
     //FIXME: 네이밍 수정해야할지도
-    @SuppressLint("CoroutineCreationDuringComposition")
     @ExperimentalFoundationApi
     @Composable
     private fun CalendarLazyColumn(yearList: List<List<CalendarSet>>) {
@@ -106,7 +106,7 @@ class YearCalendarView
         }
 
         // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
-        rememberCoroutineScope().launch {
+        LaunchedEffect(listState) {
             listState.scrollToItem(index = LAST_YEAR - 1) // preload
             listState.scrollToItem(index = getTodayItemIndex())
         }
@@ -123,7 +123,9 @@ class YearCalendarView
                 DayType.SUNDAY -> Color.Red
                 else -> Color.Black
             },
-            modifier = Modifier.layoutId(day.date.toString()).padding(top = 30.dp),
+            modifier = Modifier
+                .layoutId(day.date.toString())
+                .padding(top = 30.dp),
             textAlign = TextAlign.Center,
         )
     }
@@ -132,7 +134,9 @@ class YearCalendarView
     private fun PaddingText(day: CalendarDate) {
         Text(
             text = "${day.date.dayOfMonth}",
-            modifier = Modifier.layoutId(day.date.toString()).alpha(0f),
+            modifier = Modifier
+                .layoutId(day.date.toString())
+                .alpha(0f),
             textAlign = TextAlign.Center,
         )
     }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -132,7 +132,7 @@ class YearCalendarView
     private fun DayText(day: CalendarDate) {
         Text(
             text = "${day.date.dayOfMonth}",
-            color = when (day.dayType) {
+            color = when (day.dayType) { // FIXME: month 와 통합
                 DayType.HOLIDAY -> Color.Red
                 DayType.SATURDAY -> Color.Blue
                 DayType.SUNDAY -> Color.Red
@@ -175,6 +175,7 @@ class YearCalendarView
     fun setOnDaySecondClickListener(onDateSecondClickListener: OnDaySecondClickListener) {
         this.onDateSecondClickListener = onDateSecondClickListener
     }
+
     companion object {
         const val TAG = "YEAR_CALENDAR"
         const val INIT_YEAR = 0


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #66 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->

- set on click 기능 구현
- 클릭되면 테두리 지정
- 두번 클릭되면 second click listener 호출

## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->

<img width="350" alt="스크린샷 2021-11-09 오후 2 41 22" src="https://user-images.githubusercontent.com/55696672/140869202-ef97c90f-de77-48fb-9bb2-54d6c58e0a84.png">

- 1년 넘어갈 때 년도 표시에 약간의 애니메이션이 들어있는데 이번에 넣은건 아닙니다 ~
```kotlin
    stickyHeader {

    }
```

![Nov-09-2021 14-46-20](https://user-images.githubusercontent.com/55696672/140869393-b99e08ee-c0eb-47d9-9cec-16071348cef3.gif)

