### PR TITLE
날짜 선택 시 스케줄 다이얼로그 표시 

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/receiver/BootReceiver.kt
@@ -7,13 +7,12 @@ import android.content.Intent
 import androidx.core.content.getSystemService
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
-import com.drunkenboys.calendarun.util.extensions.notificationDate
-import com.drunkenboys.calendarun.util.localDateTimeToDate
+import com.drunkenboys.calendarun.util.extensions.notificationDateTimeMillis
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import java.util.*
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,7 +24,7 @@ class BootReceiver : BroadcastReceiver() {
     private val job = Job()
     private val coroutineScope = CoroutineScope(job)
 
-    private val today = Calendar.getInstance()
+    private val today = LocalDateTime.now()
 
     private lateinit var alarmManager: AlarmManager
 
@@ -46,8 +45,8 @@ class BootReceiver : BroadcastReceiver() {
     }
 
     private fun setAlarmIfScheduleInFuture(schedule: Schedule, context: Context) {
-        if (localDateTimeToDate(schedule.startDate).time > today.timeInMillis) {
-            val triggerAtMillis = schedule.notificationDate()
+        if (schedule.startDate > today) {
+            val triggerAtMillis = schedule.notificationDateTimeMillis()
             alarmManager.set(
                 AlarmManager.RTC_WAKEUP,
                 triggerAtMillis,

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.DialogDayScheduleBinding
+import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
 import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalDate
@@ -30,11 +31,37 @@ class DayScheduleDialog : DialogFragment() {
         dayScheduleViewModel.fetchScheduleList(LocalDate.parse(args.localDate))
 
         initRvDaySchedule()
+        initIvAddSchedule()
         observeListItem()
+        observeScheduleClickEvent()
 
         return AlertDialog.Builder(requireContext())
             .setView(binding.root)
             .create()
+    }
+
+    private fun initRvDaySchedule() {
+        binding.rvDaySchedule.adapter = dayScheduleAdapter
+    }
+
+    private fun initIvAddSchedule() {
+        binding.ivDayScheduleAddSchedule.setOnClickListener {
+            val action = DayScheduleDialogDirections.actionDayScheduleDialogToSaveScheduleFragment(BehaviorType.INSERT)
+            navController.navigate(action)
+        }
+    }
+
+    private fun observeListItem() {
+        dayScheduleViewModel.listItem.observe(this) { listItem ->
+            dayScheduleAdapter.submitList(listItem)
+        }
+    }
+
+    private fun observeScheduleClickEvent() {
+        dayScheduleViewModel.scheduleClickEvent.observe(this) {
+            val action = DayScheduleDialogDirections.actionDayScheduleDialogToSaveScheduleFragment(BehaviorType.UPDATE)
+            navController.navigate(action)
+        }
     }
 
     override fun onResume() {
@@ -43,16 +70,6 @@ class DayScheduleDialog : DialogFragment() {
         val displayMetrics = resources.displayMetrics
         dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_24dp)
         dialog?.window?.setLayout((displayMetrics.widthPixels * 0.9).toInt(), (displayMetrics.heightPixels * 0.7).toInt())
-    }
-
-    private fun initRvDaySchedule() {
-        binding.rvDaySchedule.adapter = dayScheduleAdapter
-    }
-
-    private fun observeListItem() {
-        dayScheduleViewModel.listItem.observe(this) { listItem ->
-            dayScheduleAdapter.submitList(listItem)
-        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -1,4 +1,4 @@
-package com.drunkenboys.calendarun.ui.maincalendar
+package com.drunkenboys.calendarun.ui.dayschedule
 
 import android.app.AlertDialog
 import android.os.Bundle

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -28,9 +28,22 @@ class DayScheduleDialog : DialogFragment() {
         _binding = DialogDayScheduleBinding.inflate(layoutInflater)
         dayScheduleViewModel.fetchScheduleList(LocalDate.parse(args.localDate))
 
+        initRvDaySchedule()
+        observeListItem()
+
         return AlertDialog.Builder(requireContext())
             .setView(binding.root)
             .create()
+    }
+
+    private fun initRvDaySchedule() {
+        binding.rvDaySchedule.adapter = dayScheduleAdapter
+    }
+
+    private fun observeListItem() {
+        dayScheduleViewModel.listItem.observe(this) { listItem ->
+            dayScheduleAdapter.submitList(listItem)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.DialogDayScheduleBinding
 import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleAdapter
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,6 +35,14 @@ class DayScheduleDialog : DialogFragment() {
         return AlertDialog.Builder(requireContext())
             .setView(binding.root)
             .create()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        val displayMetrics = resources.displayMetrics
+        dialog?.window?.setBackgroundDrawableResource(R.drawable.bg_white_radius_24dp)
+        dialog?.window?.setLayout((displayMetrics.widthPixels * 0.9).toInt(), (displayMetrics.heightPixels * 0.7).toInt())
     }
 
     private fun initRvDaySchedule() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -5,10 +5,11 @@ import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.drunkenboys.calendarun.databinding.DialogDayScheduleBinding
 import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleAdapter
-import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
 
 @AndroidEntryPoint
 class DayScheduleDialog : DialogFragment() {
@@ -16,14 +17,16 @@ class DayScheduleDialog : DialogFragment() {
     private var _binding: DialogDayScheduleBinding? = null
     private val binding get() = _binding ?: throw IllegalStateException()
 
-    private val dayScheduleViewModel by viewModels<SearchScheduleViewModel>()
+    private val dayScheduleViewModel by viewModels<DayScheduleViewModel>()
 
     private val dayScheduleAdapter = SearchScheduleAdapter()
 
     private val navController by lazy { findNavController() }
+    private val args by navArgs<DayScheduleDialogArgs>()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         _binding = DialogDayScheduleBinding.inflate(layoutInflater)
+        dayScheduleViewModel.fetchScheduleList(LocalDate.parse(args.localDate))
 
         return AlertDialog.Builder(requireContext())
             .setView(binding.root)

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
@@ -1,0 +1,53 @@
+package com.drunkenboys.calendarun.ui.dayschedule
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.drunkenboys.calendarun.data.idstore.IdStore
+import com.drunkenboys.calendarun.data.schedule.entity.Schedule
+import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
+import com.drunkenboys.calendarun.di.CalendarId
+import com.drunkenboys.calendarun.ui.searchschedule.model.DateItem
+import com.drunkenboys.calendarun.ui.searchschedule.model.DateScheduleItem
+import com.drunkenboys.calendarun.util.SingleLiveEvent
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class DayScheduleViewModel @Inject constructor(
+    @CalendarId private val calendarId: Long,
+    private val scheduleDataSource: ScheduleLocalDataSource
+) : ViewModel() {
+
+    private val _listItem = MutableLiveData<List<DateItem>>()
+    val listItem: LiveData<List<DateItem>> = _listItem
+
+    private val _scheduleClickEvent = SingleLiveEvent<Unit>()
+    val scheduleClickEvent: LiveData<Unit> = _scheduleClickEvent
+
+    fun fetchScheduleList(localDate: LocalDate) {
+        viewModelScope.launch {
+            _listItem.value = scheduleDataSource.fetchCalendarSchedules(calendarId)
+                .filter { it.startDate.toLocalDate() == localDate }
+                .mapToDateItem()
+        }
+    }
+
+    private fun List<Schedule>.mapToDateItem() = groupBy { schedule -> schedule.startDate.toLocalDate() }
+        .map { (localDate, scheduleList) ->
+            val dateScheduleList = scheduleList.map { schedule ->
+                DateScheduleItem(schedule) { emitScheduleClickEvent(schedule) }
+            }
+            DateItem(localDate, dateScheduleList)
+        }
+        .sortedBy { dateItem -> dateItem.date }
+
+    private fun emitScheduleClickEvent(schedule: Schedule) {
+        IdStore.putId(IdStore.KEY_CALENDAR_ID, schedule.calendarId)
+        IdStore.putId(IdStore.KEY_SCHEDULE_ID, schedule.id)
+        _scheduleClickEvent.value = Unit
+    }
+}

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
@@ -31,7 +31,7 @@ class DayScheduleViewModel @Inject constructor(
     fun fetchScheduleList(localDate: LocalDate) {
         viewModelScope.launch {
             _listItem.value = scheduleDataSource.fetchCalendarSchedules(calendarId)
-                .filter { it.startDate.toLocalDate() == localDate }
+                .filter { localDate in it.startDate.toLocalDate()..it.endDate.toLocalDate() }
                 .mapToDateItem()
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/DayScheduleDialog.kt
@@ -1,0 +1,15 @@
+package com.drunkenboys.calendarun.ui.maincalendar
+
+import android.app.AlertDialog
+import android.os.Bundle
+import androidx.fragment.app.DialogFragment
+import com.drunkenboys.calendarun.R
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class DayScheduleDialog : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog = AlertDialog.Builder(requireContext())
+        .setView(R.layout.dialog_day_schedule)
+        .create()
+}

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/DayScheduleDialog.kt
@@ -3,13 +3,35 @@ package com.drunkenboys.calendarun.ui.maincalendar
 import android.app.AlertDialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import com.drunkenboys.calendarun.R
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.drunkenboys.calendarun.databinding.DialogDayScheduleBinding
+import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleAdapter
+import com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class DayScheduleDialog : DialogFragment() {
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog = AlertDialog.Builder(requireContext())
-        .setView(R.layout.dialog_day_schedule)
-        .create()
+    private var _binding: DialogDayScheduleBinding? = null
+    private val binding get() = _binding ?: throw IllegalStateException()
+
+    private val dayScheduleViewModel by viewModels<SearchScheduleViewModel>()
+
+    private val dayScheduleAdapter = SearchScheduleAdapter()
+
+    private val navController by lazy { findNavController() }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
+        _binding = DialogDayScheduleBinding.inflate(layoutInflater)
+
+        return AlertDialog.Builder(requireContext())
+            .setView(binding.root)
+            .create()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -1,9 +1,7 @@
 package com.drunkenboys.calendarun.ui.maincalendar
 
-import android.os.Build
 import android.os.Bundle
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.core.view.GravityCompat
 import androidx.core.view.get
 import androidx.core.view.isVisible
@@ -16,10 +14,7 @@ import com.drunkenboys.calendarun.data.idstore.IdStore
 import com.drunkenboys.calendarun.databinding.FragmentMainCalendarBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
-import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
-import com.drunkenboys.ckscalendar.data.ScheduleColorType
 import dagger.hilt.android.AndroidEntryPoint
-import java.time.LocalDate
 
 @AndroidEntryPoint
 class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.fragment_main_calendar) {
@@ -43,50 +38,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         setOnDaySecondClickListener()
     }
 
-    // TODO: 임시 데이터
-    @RequiresApi(Build.VERSION_CODES.O)
-    fun createFakeSchedule(): List<CalendarScheduleObject> {
-        val today = LocalDate.now()
-
-        return listOf(
-            CalendarScheduleObject(
-                id = 0,
-                color = ScheduleColorType.YELLOW.color,
-                text = "옛스케줄옛옛",
-                startDate = today.minusDays(20),
-                endDate = today.minusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 1,
-                color = ScheduleColorType.YELLOW.color,
-                text = "뒷스케줄뒷뒷",
-                startDate = today.plusDays(2),
-                endDate = today.plusDays(7)
-            ),
-            CalendarScheduleObject(
-                id = 2,
-                color = ScheduleColorType.BLUE.color,
-                text = "앞스케줄앞앞",
-                startDate = today.minusDays(7),
-                endDate = today.minusDays(2)
-            ),
-            CalendarScheduleObject(
-                id = 3,
-                color = ScheduleColorType.MAGENTA.color,
-                text = "깍두기깍두기",
-                startDate = today.minusDays(5),
-                endDate = today.plusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 4,
-                color = ScheduleColorType.CYAN.color,
-                text = "긴스케줄긴긴",
-                startDate = today.minusDays(9),
-                endDate = today.plusDays(9)
-            ),
-        )
-    }
-
     private fun setupCalendarView() {
         // TODO: CalendarView 내부로 전환
         binding.calendarMonth.isVisible = isMonthCalendar
@@ -95,9 +46,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
     private fun setDataBinding() {
         binding.mainCalendarViewModel = mainCalendarViewModel
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            binding.calendarMonth.setSchedules(createFakeSchedule())
-        }
     }
 
     private fun setupToolbar() {
@@ -124,8 +72,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         // TODO: 2021-11-04 뷰모델 추가 시 이벤트 방식으로 변경
         binding.fabMainCalenderAddSchedule.setOnClickListener {
             // TODO: 2021-11-07 ID를 초기화하는 코드를 뷰모델로 이동해야 함
-            val id = mainCalendarViewModel.calendar.value?.id ?: return@setOnClickListener
-            IdStore.putId(IdStore.KEY_CALENDAR_ID, id)
             IdStore.clearId(IdStore.KEY_SCHEDULE_ID)
             val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSaveScheduleFragment(BehaviorType.INSERT)
             navController.navigate(action)
@@ -152,7 +98,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
     private fun setScheduleListObserver() {
         mainCalendarViewModel.scheduleList.observe(viewLifecycleOwner) { scheduleList ->
-            // TODO: 2021-11-10 Schedule 캘린더에 띄워주기
+            binding.calendarMonth.setSchedules(scheduleList)
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -40,6 +40,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         setScheduleListObserver()
         setupToolbar()
         setupFab()
+        setOnDaySecondClickListener()
     }
 
     private fun setupCalendarView() {
@@ -183,6 +184,13 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
             IdStore.putId(IdStore.KEY_CALENDAR_ID, id)
             IdStore.clearId(IdStore.KEY_SCHEDULE_ID)
             val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSaveScheduleFragment(BehaviorType.INSERT)
+            navController.navigate(action)
+        }
+    }
+
+    private fun setOnDaySecondClickListener() {
+        binding.calendarMonth.setOnDaySecondClickListener { date, _ ->
+            val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToDayScheduleDialog(date.toString())
             navController.navigate(action)
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -99,6 +99,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     private fun setScheduleListObserver() {
         mainCalendarViewModel.scheduleList.observe(viewLifecycleOwner) { scheduleList ->
             binding.calendarMonth.setSchedules(scheduleList)
+            binding.calendarYear.setSchedules(scheduleList)
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -34,19 +34,13 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         mainCalendarViewModel.fetchCalendarList()
         setupCalendarView()
         setDataBinding()
+        setupToolbar()
+        setupFab()
         setCalendarObserver()
         setCalendarListObserver()
         setCheckPointListObserver()
         setScheduleListObserver()
-        setupToolbar()
-        setupFab()
         setOnDaySecondClickListener()
-    }
-
-    private fun setupCalendarView() {
-        // TODO: CalendarView 내부로 전환
-        binding.calendarMonth.isVisible = isMonthCalendar
-        binding.calendarYear.isVisible = !isMonthCalendar
     }
 
     // TODO: 임시 데이터
@@ -93,6 +87,12 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         )
     }
 
+    private fun setupCalendarView() {
+        // TODO: CalendarView 내부로 전환
+        binding.calendarMonth.isVisible = isMonthCalendar
+        binding.calendarYear.isVisible = !isMonthCalendar
+    }
+
     private fun setDataBinding() {
         binding.mainCalendarViewModel = mainCalendarViewModel
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -104,11 +104,11 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         binding.toolbarMainCalendar.setupWithNavController(navController, binding.layoutDrawer)
         binding.toolbarMainCalendar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
-                R.id.menu_main_calendar_search -> navigateToSearchSchedule()
                 R.id.menu_main_calendar_calendar -> {
                     isMonthCalendar = !isMonthCalendar
                     setupCalendarView()
                 }
+                R.id.menu_main_calendar_search -> navigateToSearchSchedule()
                 else -> return@setOnMenuItemClickListener false
             }
             true
@@ -118,6 +118,18 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     private fun navigateToSearchSchedule() {
         val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSearchScheduleFragment()
         navController.navigate(action)
+    }
+
+    private fun setupFab() {
+        // TODO: 2021-11-04 뷰모델 추가 시 이벤트 방식으로 변경
+        binding.fabMainCalenderAddSchedule.setOnClickListener {
+            // TODO: 2021-11-07 ID를 초기화하는 코드를 뷰모델로 이동해야 함
+            val id = mainCalendarViewModel.calendar.value?.id ?: return@setOnClickListener
+            IdStore.putId(IdStore.KEY_CALENDAR_ID, id)
+            IdStore.clearId(IdStore.KEY_SCHEDULE_ID)
+            val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSaveScheduleFragment(BehaviorType.INSERT)
+            navController.navigate(action)
+        }
     }
 
     private fun setCalendarObserver() {
@@ -157,7 +169,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
         binding.navView.setNavigationItemSelectedListener { item ->
             when (item) {
-                menu[calendarList.size] -> navigateToAddSchedule()
+                menu[calendarList.size] -> navigateToSaveCalendar()
                 else -> {
                     val selectedCalendar = calendarList.find { calendar -> calendar.name == item.title } ?: throw IllegalStateException()
                     mainCalendarViewModel.setCalendar(selectedCalendar)
@@ -170,22 +182,10 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         }
     }
 
-    private fun navigateToAddSchedule() {
+    private fun navigateToSaveCalendar() {
         val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSaveCalendarFragment()
         navController.navigate(action)
         binding.layoutDrawer.closeDrawer(GravityCompat.START)
-    }
-
-    private fun setupFab() {
-        // TODO: 2021-11-04 뷰모델 추가 시 이벤트 방식으로 변경
-        binding.fabMainCalenderAddSchedule.setOnClickListener {
-            // TODO: 2021-11-07 ID를 초기화하는 코드를 뷰모델로 이동해야 함
-            val id = mainCalendarViewModel.calendar.value?.id ?: return@setOnClickListener
-            IdStore.putId(IdStore.KEY_CALENDAR_ID, id)
-            IdStore.clearId(IdStore.KEY_SCHEDULE_ID)
-            val action = MainCalendarFragmentDirections.actionMainCalendarFragmentToSaveScheduleFragment(BehaviorType.INSERT)
-            navController.navigate(action)
-        }
     }
 
     private fun setOnDaySecondClickListener() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -97,14 +97,14 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
             dateType ?: return@observe
 
             lifecycleScope.launch {
-                val calendar = Calendar.getInstance()
-
-                calendar.timeInMillis = pickDateInMillis() ?: return@launch
+                val dateInMillis = pickDateInMillis() ?: return@launch
                 val (hour, minute) = pickTime() ?: return@launch
-                calendar.set(Calendar.HOUR_OF_DAY, hour)
-                calendar.set(Calendar.MINUTE, minute)
 
-                saveScheduleViewModel.updateDate(dateToLocalDateTime(calendar.time), dateType)
+                val dateTime = dateInMillis.toDefaultLocalDateTime()
+                    .plusHours(hour.toLong())
+                    .plusMinutes(minute.toLong())
+
+                saveScheduleViewModel.updateDate(dateTime, dateType)
             }
         }
     }
@@ -162,7 +162,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
     private fun saveNotification(schedule: Schedule) {
         val alarmManager = requireContext().getSystemService<AlarmManager>() ?: return
 
-        val triggerAtMillis = schedule.notificationDate()
+        val triggerAtMillis = schedule.notificationDateTimeMillis()
         val today = Calendar.getInstance()
         if (today.timeInMillis > triggerAtMillis) return
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -13,13 +13,11 @@ import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
 import com.drunkenboys.calendarun.ui.saveschedule.model.DateType
 import com.drunkenboys.calendarun.util.SingleLiveEvent
 import com.drunkenboys.calendarun.util.extensions.getOrThrow
-import com.drunkenboys.calendarun.util.localDateTimeToDate
 import com.drunkenboys.ckscalendar.data.ScheduleColorType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
 import java.time.LocalDateTime
-import java.util.*
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -112,24 +110,11 @@ class SaveScheduleViewModel @Inject constructor(
         }
     }
 
-    /*fun Date.toFormatString(): String {
-        val calendar = Calendar.getInstance()
-        calendar.time = this
-
-        val amPm = if (calendar.get(Calendar.AM_PM) == Calendar.AM) "오전" else "오후"
-        val dateFormat = SimpleDateFormat("MM월 dd일 $amPm hh:mm", Locale.getDefault())
-
-        return dateFormat.format(this)
-    }*/
-
     fun LocalDateTime.toFormatString(): String {
-        val calendar = Calendar.getInstance()
-        calendar.time = localDateTimeToDate(this)
+        val amPm = if (hour < 12) "오전" else "오후"
+        val dateFormat = DateTimeFormatter.ofPattern("MM월 dd일 $amPm hh:mm")
 
-        val amPm = if (calendar.get(Calendar.AM_PM) == Calendar.AM) "오전" else "오후"
-        val dateFormat = SimpleDateFormat("MM월 dd일 $amPm hh:mm", Locale.getDefault())
-
-        return dateFormat.format(calendar.time)
+        return format(dateFormat)
     }
 
     fun saveSchedule() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -11,13 +11,11 @@ import com.drunkenboys.calendarun.ui.searchschedule.model.DateItem
 import com.drunkenboys.calendarun.ui.searchschedule.model.DateScheduleItem
 import com.drunkenboys.calendarun.util.SingleLiveEvent
 import com.drunkenboys.calendarun.util.extensions.getOrThrow
-import com.drunkenboys.calendarun.util.localDateTimeToDate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
-import java.util.*
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,12 +54,12 @@ class SearchScheduleViewModel @Inject constructor(
         }
     }
 
-    private fun List<Schedule>.mapToDateItem() = groupBy { schedule -> schedule.dayMillis() }
-        .map { (dayMillis, scheduleList) ->
+    private fun List<Schedule>.mapToDateItem() = groupBy { schedule -> schedule.startDate.toLocalDate() }
+        .map { (localDate, scheduleList) ->
             val dateScheduleList = scheduleList.map { schedule ->
                 DateScheduleItem(schedule) { emitScheduleClickEvent(schedule) }
             }
-            DateItem(Date(dayMillis), dateScheduleList)
+            DateItem(localDate, dateScheduleList)
         }
         .sortedBy { dateItem -> dateItem.date }
 
@@ -70,14 +68,6 @@ class SearchScheduleViewModel @Inject constructor(
         IdStore.putId(IdStore.KEY_SCHEDULE_ID, schedule.id)
         _scheduleClickEvent.value = Unit
     }
-
-    private fun Schedule.dayMillis() = Calendar.getInstance().apply {
-        time = localDateTimeToDate(this@dayMillis.startDate)
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }.timeInMillis
 
     fun searchSchedule(word: String) {
         debounceJob.cancel()

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateItem.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateItem.kt
@@ -1,15 +1,12 @@
 package com.drunkenboys.calendarun.ui.searchschedule.model
 
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 data class DateItem(
-    val date: Date,
+    val date: LocalDate,
     val scheduleList: List<DateScheduleItem>
 ) {
 
-    val dateName: String = run {
-        val df = SimpleDateFormat("M월 d일", Locale.getDefault())
-        df.format(date)
-    }
+    val dateName: String = date.format(DateTimeFormatter.ofPattern("M월 d일"))
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateScheduleItem.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateScheduleItem.kt
@@ -1,31 +1,24 @@
 package com.drunkenboys.calendarun.ui.searchschedule.model
 
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
-import com.drunkenboys.calendarun.util.localDateTimeToDate
-import java.text.SimpleDateFormat
 import java.time.LocalDateTime
-import java.util.*
-import java.util.Calendar.*
+import java.time.format.DateTimeFormatter
 
 data class DateScheduleItem(val schedule: Schedule, val onClick: () -> Unit) {
 
     val duration: String = run {
-//        val startDateFormat = SimpleDateFormat("hh:mm", Locale.getDefault())
-//        val endDateFormat = getEndDateFormat(schedule.startDate, schedule.endDate)
-//
-//        "${startDateFormat.format(schedule.startDate)} ~ ${endDateFormat.format(schedule.endDate)}"
-        "1dnjf 1dlf"
+        val startDateFormat = DateTimeFormatter.ofPattern("hh:mm")
+        val endDateFormat = getEndDateFormat(schedule.startDate, schedule.endDate)
+
+        "${schedule.startDate.format(startDateFormat)} ~ ${schedule.endDate.format(endDateFormat)}"
     }
 
-    private fun getEndDateFormat(startDate: LocalDateTime, endDate: LocalDateTime): SimpleDateFormat {
-        val startDateCal = getInstance().apply { time = localDateTimeToDate(startDate) }
-        val endDateCal = getInstance().apply { time = localDateTimeToDate(endDate) }
-
+    private fun getEndDateFormat(startDate: LocalDateTime, endDate: LocalDateTime): DateTimeFormatter {
         return when {
-            startDateCal.get(YEAR) < endDateCal.get(YEAR) -> SimpleDateFormat("yyyy년 M월 d일 hh:mm", Locale.getDefault())
-            startDateCal.get(MONTH) < endDateCal.get(MONTH) -> SimpleDateFormat("M월 d일 hh:mm", Locale.getDefault())
-            startDateCal.get(DAY_OF_YEAR) < endDateCal.get(DAY_OF_YEAR) -> SimpleDateFormat("d일 hh:mm", Locale.getDefault())
-            else -> SimpleDateFormat("hh:mm", Locale.getDefault())
+            startDate.year < endDate.year -> DateTimeFormatter.ofPattern("yyyy년 M월 d일 hh:mm")
+            startDate.month < endDate.month -> DateTimeFormatter.ofPattern("M월 d일 hh:mm")
+            startDate.dayOfYear < endDate.dayOfYear -> DateTimeFormatter.ofPattern("d일 hh:mm")
+            else -> DateTimeFormatter.ofPattern("hh:mm")
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateScheduleItem.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/model/DateScheduleItem.kt
@@ -10,10 +10,11 @@ import java.util.Calendar.*
 data class DateScheduleItem(val schedule: Schedule, val onClick: () -> Unit) {
 
     val duration: String = run {
-        val startDateFormat = SimpleDateFormat("hh:mm", Locale.getDefault())
-        val endDateFormat = getEndDateFormat(schedule.startDate, schedule.endDate)
-
-        "${startDateFormat.format(schedule.startDate)} ~ ${endDateFormat.format(schedule.endDate)}"
+//        val startDateFormat = SimpleDateFormat("hh:mm", Locale.getDefault())
+//        val endDateFormat = getEndDateFormat(schedule.startDate, schedule.endDate)
+//
+//        "${startDateFormat.format(schedule.startDate)} ~ ${endDateFormat.format(schedule.endDate)}"
+        "1dnjf 1dlf"
     }
 
     private fun getEndDateFormat(startDate: LocalDateTime, endDate: LocalDateTime): SimpleDateFormat {

--- a/app/src/main/java/com/drunkenboys/calendarun/util/DateConverter.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/DateConverter.kt
@@ -1,24 +1,15 @@
 package com.drunkenboys.calendarun.util
 
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import java.util.*
+
+val defaultZoneOffset = ZoneOffset.systemDefault().rules.getOffset(Instant.now())
 
 fun localDateToString(date: LocalDate): String = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
 
 fun stringToLocalDate(date: String): LocalDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy.MM.dd"))
 
-fun dateToLocalDateTime(date: Date): LocalDateTime = date.toInstant()
-    .atZone(ZoneId.systemDefault())
-    .toLocalDateTime()
-
-fun localDateTimeToDate(localDateTime: LocalDateTime): Date = Date.from(localDateTime.toInstant(ZoneOffset.UTC))
-
-fun dateToLocalDate(date: Date): LocalDate = date.toInstant()
-    .atZone(ZoneId.systemDefault())
-    .toLocalDate()
-
-fun localDateToDate(localDate: LocalDate): Date = Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant())
+fun Long.toDefaultLocalDateTime(): LocalDateTime = LocalDateTime.ofEpochSecond(this / 1000, 0, defaultZoneOffset)

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/ScheduleExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/ScheduleExt.kt
@@ -1,19 +1,13 @@
 package com.drunkenboys.calendarun.util.extensions
 
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
-import com.drunkenboys.calendarun.util.localDateTimeToDate
-import java.util.*
+import com.drunkenboys.calendarun.util.defaultZoneOffset
 
-fun Schedule.notificationDate(): Long {
-    val calendar = Calendar.getInstance()
-    calendar.time = localDateTimeToDate(startDate)
-
-    when (notificationType) {
+fun Schedule.notificationDateTimeMillis(): Long {
+    return when (notificationType) {
         Schedule.NotificationType.NONE -> return 0
-        Schedule.NotificationType.TEN_MINUTES_AGO -> calendar.add(Calendar.MINUTE, -10)
-        Schedule.NotificationType.A_HOUR_AGO -> calendar.add(Calendar.HOUR_OF_DAY, -1)
-        Schedule.NotificationType.A_DAY_AGO -> calendar.add(Calendar.DAY_OF_YEAR, -1)
-    }
-
-    return calendar.timeInMillis
+        Schedule.NotificationType.TEN_MINUTES_AGO -> startDate.minusMinutes(10).toEpochSecond(defaultZoneOffset)
+        Schedule.NotificationType.A_HOUR_AGO -> startDate.minusHours(1).toEpochSecond(defaultZoneOffset)
+        Schedule.NotificationType.A_DAY_AGO -> startDate.minusDays(1).toEpochSecond(defaultZoneOffset)
+    } * 1000
 }

--- a/app/src/main/res/drawable/bg_white_radius_24dp.xml
+++ b/app/src/main/res/drawable/bg_white_radius_24dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="24dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_day_schedule.xml
+++ b/app/src/main/res/layout/dialog_day_schedule.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
-    tools:context=".ui.maincalendar.DayScheduleDialog">
+    tools:context=".ui.dayschedule.DayScheduleDialog">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_day_schedule.xml
+++ b/app/src/main/res/layout/dialog_day_schedule.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".ui.maincalendar.DayScheduleDialog">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/iv_daySchedule_addSchedule"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="@string/contentDescription_ivAddSchedule"
+            android:padding="8dp"
+            android:src="@drawable/ic_add" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_daySchedule"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/item_date" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/dialog_day_schedule.xml
+++ b/app/src/main/res/layout/dialog_day_schedule.xml
@@ -1,35 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="16dp"
+    android:orientation="vertical"
     tools:context=".ui.dayschedule.DayScheduleDialog">
 
-    <LinearLayout
+    <ImageView
+        android:id="@+id/iv_daySchedule_addSchedule"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="end"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:contentDescription="@string/contentDescription_ivAddSchedule"
+        android:src="@drawable/ic_add" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_daySchedule"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/item_date" />
 
-        <ImageView
-            android:id="@+id/iv_daySchedule_addSchedule"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:contentDescription="@string/contentDescription_ivAddSchedule"
-            android:padding="8dp"
-            android:src="@drawable/ic_add" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_daySchedule"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            tools:listitem="@layout/item_date" />
-
-    </LinearLayout>
-
-</com.google.android.material.card.MaterialCardView>
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -79,7 +79,7 @@
 
     <dialog
         android:id="@+id/dayScheduleDialog"
-        android:name="com.drunkenboys.calendarun.ui.maincalendar.DayScheduleDialog"
+        android:name="com.drunkenboys.calendarun.ui.dayschedule.DayScheduleDialog"
         android:label="DayScheduleDialog"
         tools:layout="@layout/dialog_day_schedule">
         <argument

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -31,6 +31,9 @@
             app:exitAnim="@anim/slide_out_left"
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
+        <action
+            android:id="@+id/action_mainCalendarFragment_to_dayScheduleDialog"
+            app:destination="@id/dayScheduleDialog" />
     </fragment>
 
     <fragment
@@ -73,5 +76,15 @@
             app:popEnterAnim="@anim/slide_in_left"
             app:popExitAnim="@anim/slide_out_right" />
     </fragment>
+
+    <dialog
+        android:id="@+id/dayScheduleDialog"
+        android:name="com.drunkenboys.calendarun.ui.maincalendar.DayScheduleDialog"
+        android:label="DayScheduleDialog"
+        tools:layout="@layout/dialog_day_schedule">
+        <argument
+            android:name="localDate"
+            app:argType="string" />
+    </dialog>
 
 </navigation>

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -85,6 +85,13 @@
         <argument
             android:name="localDate"
             app:argType="string" />
+        <action
+            android:id="@+id/action_dayScheduleDialog_to_saveScheduleFragment"
+            app:destination="@id/saveScheduleFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
     </dialog>
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,4 +52,6 @@
 
     <string name="toast_schedule_saved">일정이 저장되었습니다</string>
     <string name="toast_schedule_deleted">일정이 삭제되었습니다</string>
+
+    <string name="contentDescription_ivAddSchedule">일정 추가 버튼</string>
 </resources>

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
@@ -2,7 +2,7 @@ package com.drunkenboys.calendarun.data.schedule.local
 
 import com.drunkenboys.calendarun.data.calendar.entity.Calendar
 import com.drunkenboys.calendarun.data.calendar.local.CalendarLocalDataSource
-import java.util.*
+import java.time.LocalDate
 
 class FakeCalendarLocalDataSource : CalendarLocalDataSource {
 
@@ -15,6 +15,6 @@ class FakeCalendarLocalDataSource : CalendarLocalDataSource {
     }
 
     override suspend fun fetchCalendar(id: Long): Calendar {
-        return Calendar(0, "test calendar", Date(), Date())
+        return Calendar(0, "test calendar", LocalDate.now(), LocalDate.now())
     }
 }

--- a/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModelTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.*
+import java.time.LocalDateTime
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
@@ -58,8 +58,8 @@ class SaveScheduleViewModelTest {
 
     @Test
     fun `일정_수정_시_뷰모델_초기화_테스트`() = testScope.runBlockingTest {
-        val startDate = Date()
-        val endDate = Date()
+        val startDate = LocalDateTime.now()
+        val endDate = LocalDateTime.now()
         scheduleDataSource.insertSchedule(Schedule(0, 0, "test", startDate, endDate, Schedule.NotificationType.A_HOUR_AGO, "memo", 0))
 
         viewModel.init(BehaviorType.UPDATE)
@@ -97,8 +97,8 @@ class SaveScheduleViewModelTest {
 
     @Test
     fun `일정_삭제_테스트`() = testScope.runBlockingTest {
-        val startDate = Date()
-        val endDate = Date()
+        val startDate = LocalDateTime.now()
+        val endDate = LocalDateTime.now()
         val schedule = Schedule(0, 0, "test", startDate, endDate, Schedule.NotificationType.A_HOUR_AGO, "memo", 0)
         scheduleDataSource.insertSchedule(schedule)
         viewModel.init(BehaviorType.UPDATE)

--- a/app/src/test/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModelTest.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.time.LocalDateTime
 import java.util.*
 
 @ObsoleteCoroutinesApi
@@ -44,11 +45,8 @@ class SearchScheduleViewModelTest {
 
     @Test
     fun `이후_일정이_있을_때_초기_검색_테스트`() = testScope.runBlockingTest {
-        val tomorrowCalendar = Calendar.getInstance()
-        tomorrowCalendar.add(Calendar.DAY_OF_YEAR, 1)
-        val yesterdayCalendar = Calendar.getInstance()
-        yesterdayCalendar.add(Calendar.DAY_OF_YEAR, -1)
-        initDataSource(dateList = arrayOf(yesterdayCalendar.time, tomorrowCalendar.time))
+        val localDateTime = LocalDateTime.now()
+        initDataSource(dateList = arrayOf(localDateTime.minusDays(1), localDateTime.plusDays(1)))
 
         viewModel.fetchScheduleList()
         val result = viewModel.listItem.value
@@ -62,9 +60,8 @@ class SearchScheduleViewModelTest {
 
     @Test
     fun `이후_일정이_없을_때_초기_검색_테스트`() = testScope.runBlockingTest {
-        val yesterdayCalendar = Calendar.getInstance()
-        yesterdayCalendar.add(Calendar.DAY_OF_YEAR, -1)
-        initDataSource(dateList = arrayOf(yesterdayCalendar.time, yesterdayCalendar.time))
+        val localDateTime = LocalDateTime.now()
+        initDataSource(dateList = arrayOf(localDateTime.minusDays(1), localDateTime.minusDays(1)))
 
         viewModel.fetchScheduleList()
         val result = viewModel.listItem.value
@@ -78,7 +75,7 @@ class SearchScheduleViewModelTest {
 
     @Test
     fun `검색_기능_테스트`() = testScope.runBlockingTest {
-        val date = Date()
+        val date = LocalDateTime.now()
         initDataSource(name = "foo", dateList = arrayOf(date, date, date))
         initDataSource(name = "bar", dateList = arrayOf(date, date, date, date))
         initDataSource(name = "quz", dateList = arrayOf(date, date))
@@ -96,7 +93,7 @@ class SearchScheduleViewModelTest {
         assertTrue(result[0].scheduleList.all { it.schedule.name.startsWith("bar") })
     }
 
-    private suspend fun initDataSource(name: String = "name", vararg dateList: Date) {
+    private suspend fun initDataSource(name: String = "name", vararg dateList: LocalDateTime) {
         dateList.forEachIndexed { index, date ->
             dataSource.insertSchedule(
                 Schedule(
@@ -104,7 +101,7 @@ class SearchScheduleViewModelTest {
                     calendarId = 1,
                     name = "$name$index",
                     startDate = date,
-                    endDate = Date(),
+                    endDate = LocalDateTime.now(),
                     notificationType = Schedule.NotificationType.NONE,
                     memo = "memo$index",
                     color = 0


### PR DESCRIPTION
## what is this pr
- 현재 캘린더가 선택될 때 스케줄 목록을 업데이트하기 때문에 데이터 변경시 캘린더를 선택하는 과정이 필요함
- 달력이 선택됐을 때 일정이 겹쳐지는 이슈가 있음

Resolve: #90

## Changes
- 선택한 요일의 스케줄을 보여주는 다이얼로그 추가
- 다이얼로그 -> 프래그먼트 내비게이션 구성
- 캘린더에 스케줄 추가

## screenshot
<img src="https://user-images.githubusercontent.com/52354794/141115374-6df59622-00d3-481e-95ee-469d3bf18be3.gif" width=350 />
