### PR TITLE
ScheduleObject: LocalDate -> LocalDateTime

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -49,55 +49,8 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         binding.calendarYear.isVisible = !isMonthCalendar
     }
 
-    // TODO: 임시 데이터
-    @RequiresApi(Build.VERSION_CODES.O)
-    fun createFakeSchedule(): List<CalendarScheduleObject> {
-        val today = LocalDateTime.now()
-
-        return listOf(
-            CalendarScheduleObject(
-                id = 0,
-                color = ScheduleColorType.YELLOW.color,
-                text = "옛스케줄옛옛",
-                startDate = today.minusDays(20),
-                endDate = today.minusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 1,
-                color = ScheduleColorType.YELLOW.color,
-                text = "뒷스케줄뒷뒷",
-                startDate = today.plusDays(2),
-                endDate = today.plusDays(7)
-            ),
-            CalendarScheduleObject(
-                id = 2,
-                color = ScheduleColorType.BLUE.color,
-                text = "앞스케줄앞앞",
-                startDate = today.minusDays(7),
-                endDate = today.minusDays(2)
-            ),
-            CalendarScheduleObject(
-                id = 3,
-                color = ScheduleColorType.MAGENTA.color,
-                text = "깍두기깍두기",
-                startDate = today.minusDays(5),
-                endDate = today.plusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 4,
-                color = ScheduleColorType.CYAN.color,
-                text = "긴스케줄긴긴",
-                startDate = today.minusDays(9),
-                endDate = today.plusDays(9)
-            )
-        )
-    }
-
     private fun setDataBinding() {
         binding.mainCalendarViewModel = mainCalendarViewModel
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            binding.calendarMonth.setSchedules(createFakeSchedule())
-        }
     }
 
     private fun setupToolbar() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -65,7 +65,7 @@ class MainCalendarViewModel @Inject constructor(
         id = id.toInt(),
         color = color,
         text = name,
-        startDate = startDate.toLocalDate(),
-        endDate = endDate.toLocalDate()
+        startDate = startDate,
+        endDate = endDate
     )
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/FakeFactory.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/FakeFactory.kt
@@ -8,17 +8,17 @@ object FakeFactory {
 
     // TODO: 나중에 디자인 요소 결정하기
     fun createFakeDesign() = CalendarDesignObject(
-            weekDayTextColor = TimeUtils.getColorInt(0, 0, 0),
-            holidayTextColor = ScheduleColorType.RED.color,
-            saturdayTextColor = ScheduleColorType.BLUE.color,
-            sundayTextColor = ScheduleColorType.RED.color,
-            textSize = 10,
-            textAlign = 1,
-            selectedFrameColor = ScheduleColorType.MAGENTA.color,
-            backgroundColor = TimeUtils.getColorInt(255, 255, 255),
-            weekSimpleStringSet = listOf("일", "월", "화", "수", "목", "금", "토"),
-            weekFullStringSet = listOf("일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"),
-            visibleScheduleCount = 3
+        weekDayTextColor = TimeUtils.getColorInt(0, 0, 0),
+        holidayTextColor = ScheduleColorType.RED.color,
+        saturdayTextColor = ScheduleColorType.BLUE.color,
+        sundayTextColor = ScheduleColorType.RED.color,
+        textSize = 10,
+        textAlign = 1,
+        selectedFrameColor = ScheduleColorType.MAGENTA.color,
+        backgroundColor = TimeUtils.getColorInt(255, 255, 255),
+        weekSimpleStringSet = listOf("일", "월", "화", "수", "목", "금", "토"),
+        weekFullStringSet = listOf("일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"),
+        visibleScheduleCount = 3
     )
 
     fun createFakeCalendarSetList(year: Int): List<CalendarSet> {
@@ -33,47 +33,5 @@ object FakeFactory {
         }
 
         return calendarMonth
-    }
-
-    fun createFakeSchedule(): List<CalendarScheduleObject> {
-        val today = LocalDate.now()
-
-        return listOf(
-            CalendarScheduleObject(
-                id = 0,
-                color = ScheduleColorType.YELLOW.color,
-                text = "옛스케줄옛옛",
-                startDate = today.minusDays(20),
-                endDate = today.minusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 1,
-                color = ScheduleColorType.YELLOW.color,
-                text = "뒷스케줄뒷뒷",
-                startDate = today.plusDays(2),
-                endDate = today.plusDays(7)
-            ),
-            CalendarScheduleObject(
-                id = 2,
-                color = ScheduleColorType.BLUE.color,
-                text = "앞스케줄앞앞",
-                startDate = today.minusDays(7),
-                endDate = today.minusDays(2)
-            ),
-            CalendarScheduleObject(
-                id = 3,
-                color = ScheduleColorType.MAGENTA.color,
-                text = "깍두기깍두기",
-                startDate = today.minusDays(5),
-                endDate = today.plusDays(5)
-            ),
-            CalendarScheduleObject(
-                id = 4,
-                color = ScheduleColorType.CYAN.color,
-                text = "긴스케줄긴긴",
-                startDate = today.minusDays(9),
-                endDate = today.plusDays(9)
-            )
-        )
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/FakeFactory.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/FakeFactory.kt
@@ -6,21 +6,6 @@ import java.time.LocalDate
 
 object FakeFactory {
 
-    // TODO: 나중에 디자인 요소 결정하기
-    fun createFakeDesign() = CalendarDesignObject(
-        weekDayTextColor = TimeUtils.getColorInt(0, 0, 0),
-        holidayTextColor = ScheduleColorType.RED.color,
-        saturdayTextColor = ScheduleColorType.BLUE.color,
-        sundayTextColor = ScheduleColorType.RED.color,
-        textSize = 10,
-        textAlign = 1,
-        selectedFrameColor = ScheduleColorType.MAGENTA.color,
-        backgroundColor = TimeUtils.getColorInt(255, 255, 255),
-        weekSimpleStringSet = listOf("일", "월", "화", "수", "목", "금", "토"),
-        weekFullStringSet = listOf("일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"),
-        visibleScheduleCount = 3
-    )
-
     fun createFakeCalendarSetList(year: Int): List<CalendarSet> {
         val calendarMonth = mutableListOf<CalendarSet>()
         var startOfMonth: LocalDate

--- a/library/src/main/java/com/drunkenboys/ckscalendar/data/CalendarDesignObject.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/data/CalendarDesignObject.kt
@@ -1,18 +1,19 @@
 package com.drunkenboys.ckscalendar.data
 
 import androidx.annotation.ColorInt
+import com.drunkenboys.ckscalendar.utils.TimeUtils
 
 data class CalendarDesignObject(
-    @ColorInt val weekDayTextColor: Int,
-    @ColorInt val holidayTextColor: Int,
-    @ColorInt val saturdayTextColor: Int,
-    @ColorInt val sundayTextColor: Int,
-    val textSize: Int,
-    val textAlign: Int, // TODO: gravity 매퍼
-    @ColorInt val selectedFrameColor: Int,
-    @ColorInt val backgroundColor: Int,
-    val weekSimpleStringSet: List<String>,
-    val weekFullStringSet: List<String>,
-    val visibleScheduleCount: Int
+    @ColorInt val weekDayTextColor: Int = TimeUtils.getColorInt(0, 0, 0),
+    @ColorInt val holidayTextColor: Int = ScheduleColorType.RED.color,
+    @ColorInt val saturdayTextColor: Int = ScheduleColorType.BLUE.color,
+    @ColorInt val sundayTextColor: Int = ScheduleColorType.RED.color,
+    val textSize: Int = 10,
+    val textAlign: Int = 1, // TODO: gravity 매퍼
+    @ColorInt val selectedFrameColor: Int = ScheduleColorType.MAGENTA.color,
+    @ColorInt val backgroundColor: Int = TimeUtils.getColorInt(255, 255, 255),
+    val weekSimpleStringSet: List<String> = listOf("일", "월", "화", "수", "목", "금", "토"),
+    val weekFullStringSet: List<String> = listOf("일요일", "월요일", "화요일", "수요일", "목요일", "금요일", "토요일"),
+    val visibleScheduleCount: Int = 3
     // TODO: frame shape
 )

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarController.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarController.kt
@@ -14,10 +14,10 @@ class YearCalendarController {
     }
 
     fun getStartScheduleList(today: LocalDate, scheduleList: List<CalendarScheduleObject>) = scheduleList.filter { schedule ->
-        val isStart = schedule.startDate == today
+        val isStart = schedule.startDate.toLocalDate() == today
         val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
         val isFirstOfMonth = today.dayOfMonth == 1
-        val isDateInScheduleRange = today in schedule.startDate..schedule.endDate
+        val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
         isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
     }
 
@@ -30,7 +30,7 @@ class YearCalendarController {
 
         todaySchedules.forEach { todaySchedule ->
             val weekEndDate =
-                if (!today.isSameWeek(todaySchedule.endDate)) DayOfWeek.SATURDAY.value
+                if (!today.isSameWeek(todaySchedule.endDate.toLocalDate())) DayOfWeek.SATURDAY.value
                 else todaySchedule.endDate.dayOfWeek.dayValue()
 
             weekSchedules[todayOfWeek].forEachIndexed { index, space ->

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -45,7 +45,7 @@ class YearCalendarView
 
     private val controller = YearCalendarController()
 
-    private var design = FakeFactory.createFakeDesign()
+    private var design = CalendarDesignObject()
 
     private var onDateClickListener: OnDayClickListener? = null
     private var onDateSecondClickListener: OnDaySecondClickListener? = null
@@ -277,8 +277,7 @@ class YearCalendarView
     }
 
     fun resetTheme() {
-        // FIXME
-        design = FakeFactory.createFakeDesign()
+        design = CalendarDesignObject()
     }
 
     companion object {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -202,6 +202,14 @@ class YearCalendarView
     ) {
         val weekNum = (today.dayOfWeek.dayValue())
 
+        val scheduleText = { schedule: CalendarScheduleObject? ->
+            when {
+                schedule == null -> " "
+                schedule.startDate.toLocalDate() == today || today.dayOfWeek == DayOfWeek.SUNDAY -> schedule.text
+                else -> " "
+            }
+        }
+
         with(controller) {
             setWeekSchedule(getStartScheduleList(today, scheduleList), weekScheduleList, today)
         }
@@ -212,7 +220,7 @@ class YearCalendarView
                 else Modifier.fillMaxWidth()
 
             Text(
-                text = if (schedule?.startDate == today || today.dayOfWeek == DayOfWeek.SUNDAY) schedule?.text ?: " " else " ",
+                text = scheduleText(schedule),
                 maxLines = 1,
                 modifier = modifier,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Related: #93
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- main Fragment, ViewModel 자료형 맞춰서 수정
- year calendar LocalDateTime 적용

## Issues

- 2021.11.1 달력 추가하면 parse 에러 발생
```
 Process: com.drunkenboys.calendarun, PID: 7622
    java.time.format.DateTimeParseException: Text '2021.11.1' could not be parsed at index 8
        at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949)
        at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851)
        at java.time.LocalDate.parse(LocalDate.java:394)
        at com.drunkenboys.calendarun.util.DateConverterKt.stringToLocalDate(DateConverter.kt:13)
        at com.drunkenboys.calendarun.ui.savecalendar.SaveCalendarViewModel.isValidateCalendarDate(SaveCalendarViewModel.kt:131)
        at com.drunkenboys.calendarun.ui.savecalendar.SaveCalendarViewModel.saveCalendar(SaveCalendarViewModel.kt:95)
        at com.drunkenboys.calendarun.ui.savecalendar.SaveCalendarViewModel.emitSaveCalendar(SaveCalendarViewModel.kt:69)
        at com.drunkenboys.calendarun.databinding.FragmentSaveCalendarBindingImpl._internalCallbackOnClick(FragmentSaveCalendarBindingImpl.java:348)
        at com.drunkenboys.calendarun.generated.callback.OnClickListener.onClick(OnClickListener.java:11)
        at android.view.View.performClick(View.java:7447)
```
