### PR TITLE
스케줄 TextView 높이에 맞는 fontSize로 자동적용

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthAdapter.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthAdapter.kt
@@ -170,14 +170,15 @@ class MonthAdapter(val onDaySelectStateListener: OnDaySelectStateListener) : Rec
                 LinearLayout.LayoutParams.WRAP_CONTENT
             )
             layoutParams.setMargins(0, 0, 0, context().dp2px(2.0f).toInt())
+            textView.includeFontPadding = false
             textView.isSingleLine = true
             textView.layoutParams = layoutParams
-            textView.height = calculateHeight / SCHEDULE_HEIGHT_DIVIDE_RATIO
             textView.gravity = Gravity.CENTER_VERTICAL
             textView.maxLines = 1
             textView.ellipsize = TextUtils.TruncateAt.END
-            textView.setPadding(context().dp2px(2.0f).toInt(), 0, 0, 0)
-            textView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 10f)
+            val textSize = calculateHeight / SCHEDULE_HEIGHT_DIVIDE_RATIO
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize.toFloat())
+            textView.setPadding(context().dp2px(2.0f).toInt(), 0, 0, context().dp2px(2.0f).toInt())
             return textView
         }
 
@@ -214,7 +215,7 @@ class MonthAdapter(val onDaySelectStateListener: OnDaySelectStateListener) : Rec
 
         private const val CALENDAR_COLUMN_SIZE = 7
 
-        private const val SCHEDULE_HEIGHT_DIVIDE_RATIO = 6
+        private const val SCHEDULE_HEIGHT_DIVIDE_RATIO = 10
 
         //TODO : 10개넘어가는 일정이 있으면 오류 가능성 있음
         private const val SCHEDULE_CONTAINER_SIZE = 10


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolved: #102 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 스케줄 TextView 높이를 fontSize로 지정 
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/13197242/141248610-8b9d1e61-8573-4648-ac59-83fa9d2455fa.png" width=350 />

![image](https://user-images.githubusercontent.com/13197242/141248726-eedc7e17-c2f3-4b54-b4b5-7b204d6fb01e.png)
