### PR TITLE
DayScheduleDialog.kt 스케줄 추가할 때  Id 오류 수정 

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleDialog.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.drunkenboys.calendarun.R
+import com.drunkenboys.calendarun.data.idstore.IdStore
 import com.drunkenboys.calendarun.databinding.DialogDayScheduleBinding
 import com.drunkenboys.calendarun.ui.saveschedule.model.BehaviorType
 import com.drunkenboys.calendarun.util.extensions.sharedCollect
@@ -56,6 +57,7 @@ class DayScheduleDialog : DialogFragment() {
 
     private fun setupIvAddSchedule() {
         binding.imgDayScheduleAddSchedule.setOnClickListener {
+            IdStore.clearId(IdStore.KEY_SCHEDULE_ID)
             val action = DayScheduleDialogDirections.actionDayScheduleDialogToSaveScheduleFragment(BehaviorType.INSERT, args.localDate)
             navController.navigate(action)
         }


### PR DESCRIPTION

## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- DayScheduleDialog.kt 스케줄 추가할때 이전에 선택된 Id가 있으면 unique 오류 발생하는 버그 수정 

