### PR TITLE
Flow 확장함수 수정

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
@@ -54,8 +54,8 @@ suspend fun Fragment.pickTime() = suspendCancellableCoroutine<Pair<Int, Int>?> {
 }
 
 fun <T> Fragment.stateCollect(stateFlow: StateFlow<T>, block: suspend (T) -> Unit) {
-    lifecycleScope.launch {
-        repeatOnLifecycle(Lifecycle.State.STARTED) {
+    viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             stateFlow.collect {
                 block(it)
             }
@@ -64,7 +64,7 @@ fun <T> Fragment.stateCollect(stateFlow: StateFlow<T>, block: suspend (T) -> Uni
 }
 
 fun <T> Fragment.sharedCollect(sharedFlow: SharedFlow<T>, block: suspend (T) -> Unit) {
-    lifecycleScope.launch {
+    viewLifecycleOwner.lifecycleScope.launch {
         sharedFlow.collectLatest {
             block(it)
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
@@ -53,7 +53,7 @@ suspend fun Fragment.pickTime() = suspendCancellableCoroutine<Pair<Int, Int>?> {
     timePicker.show(parentFragmentManager, timePicker::class.simpleName)
 }
 
-fun <T> Fragment.stateCollect(stateFlow: StateFlow<T>, block: suspend (T) -> Unit) {
+inline fun <T> Fragment.stateCollect(stateFlow: StateFlow<T>, crossinline block: suspend (T) -> Unit) {
     viewLifecycleOwner.lifecycleScope.launch {
         viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
             stateFlow.collect {
@@ -63,7 +63,7 @@ fun <T> Fragment.stateCollect(stateFlow: StateFlow<T>, block: suspend (T) -> Uni
     }
 }
 
-fun <T> Fragment.sharedCollect(sharedFlow: SharedFlow<T>, block: suspend (T) -> Unit) {
+inline fun <T> Fragment.sharedCollect(sharedFlow: SharedFlow<T>, crossinline block: suspend (T) -> Unit) {
     viewLifecycleOwner.lifecycleScope.launch {
         sharedFlow.collectLatest {
             block(it)


### PR DESCRIPTION
## what is this pr

Resolve: #149 

## Changes
- Fragment에서 flow를 수집하는 lifecycle owner를 viewLifecycleOwner로 변경
- 확장함수를 inline 함수로 변경

