### PR TITLE
내비게이션 충돌 해결

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -17,6 +17,7 @@ import com.drunkenboys.calendarun.data.calendar.entity.Calendar
 import com.drunkenboys.calendarun.databinding.DrawerHeaderBinding
 import com.drunkenboys.calendarun.databinding.FragmentMainCalendarBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
+import com.drunkenboys.calendarun.util.extensions.navigateSafe
 import com.drunkenboys.calendarun.util.extensions.sharedCollect
 import com.drunkenboys.calendarun.util.extensions.stateCollect
 import com.drunkenboys.calendarun.util.extensions.throttleFirst
@@ -187,7 +188,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
                 mainCalendarViewModel.daySecondClickEvent.throttleFirst(DEFAULT_TOUCH_THROTTLE_PERIOD).collect { date ->
                     val calendarId = mainCalendarViewModel.calendar.value?.id ?: throw IllegalStateException("calendarId is null")
                     val action = MainCalendarFragmentDirections.toDayScheduleDialog(calendarId, date.toString())
-                    navController.navigate(action)
+                    navController.navigateSafe(action)
                 }
             }
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -185,11 +185,13 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         // TODO: 2021-11-16 현재 flow 확장함수가 StateFlow와 SharedFlow만 받기 때문에 라이프사이클 처리를 명시해주고 있는데 개선이 필요해보임.
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                mainCalendarViewModel.daySecondClickEvent.throttleFirst(DEFAULT_TOUCH_THROTTLE_PERIOD).collect { date ->
-                    val calendarId = mainCalendarViewModel.calendar.value?.id ?: throw IllegalStateException("calendarId is null")
-                    val action = MainCalendarFragmentDirections.toDayScheduleDialog(calendarId, date.toString())
-                    navController.navigateSafe(action)
-                }
+                mainCalendarViewModel.daySecondClickEvent
+                    .throttleFirst(DEFAULT_TOUCH_THROTTLE_PERIOD)
+                    .collect { date ->
+                        val calendarId = mainCalendarViewModel.calendar.value?.id ?: throw IllegalStateException("calendarId is null")
+                        val action = MainCalendarFragmentDirections.toDayScheduleDialog(calendarId, date.toString())
+                        navController.navigateSafe(action)
+                    }
             }
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,6 +42,9 @@ class MainCalendarViewModel @Inject constructor(
 
     private val _fabClickEvent = MutableSharedFlow<Long>()
     val fabClickEvent: SharedFlow<Long> = _fabClickEvent
+
+    private val _daySecondClickEvent = MutableSharedFlow<LocalDate>()
+    val daySecondClickEvent: SharedFlow<LocalDate> = _daySecondClickEvent
 
     fun setCalendar(calendar: Calendar) {
         viewModelScope.launch {
@@ -87,6 +91,12 @@ class MainCalendarViewModel @Inject constructor(
     fun emitFabClickEvent() {
         viewModelScope.launch {
             _fabClickEvent.emit(calendar.value?.id ?: 0)
+        }
+    }
+
+    fun emitDaySecondClickEvent(date: LocalDate) {
+        viewModelScope.launch {
+            _daySecondClickEvent.emit(date)
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FlowExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FlowExt.kt
@@ -1,0 +1,20 @@
+package com.drunkenboys.calendarun.util.extensions
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+
+// from https://proandroiddev.com/from-rxjava-to-kotlin-flow-throttling-ed1778847619
+fun <T> Flow<T>.throttleFirst(periodMillis: Long): Flow<T> {
+    require(periodMillis > 0) { "period should be positive" }
+    return flow {
+        var lastTime = 0L
+        collect { value ->
+            val currentTime = System.currentTimeMillis()
+            if (currentTime - lastTime >= periodMillis) {
+                lastTime = currentTime
+                emit(value)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/NavigationExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/NavigationExt.kt
@@ -8,7 +8,6 @@ import androidx.navigation.NavDirections
  * 이동할 수 있는 destination이 있는지 확인 후 navigate.
  */
 fun NavController.navigateSafe(action: NavDirections) {
-    val currentDestination = currentDestination ?: return
-    currentDestination.getAction(action.actionId) ?: return
+    currentDestination?.getAction(action.actionId) ?: return
     navigate(action)
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/NavigationExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/NavigationExt.kt
@@ -1,0 +1,14 @@
+package com.drunkenboys.calendarun.util.extensions
+
+import androidx.navigation.NavController
+import androidx.navigation.NavDirections
+
+/**
+ * NavController의 현재 destination에서 해당 action으로
+ * 이동할 수 있는 destination이 있는지 확인 후 navigate.
+ */
+fun NavController.navigateSafe(action: NavDirections) {
+    val currentDestination = currentDestination ?: return
+    currentDestination.getAction(action.actionId) ?: return
+    navigate(action)
+}


### PR DESCRIPTION
## what is this pr
- 이 PR에서는 내비게이션에서 충돌이 나는 부분만 처리를 해놨습니다.
- throttle이 추가되면서 Lifecycle 처리를 따로 해야 했는데 기존의 Flow 확장함수(stateCollect, sharedCollect)의 구조를 바꾸는게 좋을 것 같네요

Resolve: #148 

## Changes
- Flow throttleFirst operator 추가
- dayOnClickListener 동작 방식 변경
- 현재 destination과 target destination을 확인하여 안전히 이동하는 navigateSafe 함수 추가
