### PR TITLE
연달력 버그 수정

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -63,9 +63,4 @@ class YearCalendarView
     fun resetTheme() {
         viewModel.resetDesign()
     }
-
-    companion object {
-        const val INIT_YEAR = 0
-        const val LAST_YEAR = 10000
-    }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -1,8 +1,10 @@
 package com.drunkenboys.ckscalendar.yearcalendar
 
+import android.util.Log
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.drunkenboys.ckscalendar.FakeFactory
+import com.drunkenboys.ckscalendar.data.CalendarDate
 import com.drunkenboys.ckscalendar.data.CalendarDesignObject
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.data.CalendarSet
@@ -39,15 +41,6 @@ class YearCalendarViewModel: ViewModel() {
         _design.value = CalendarDesignObject()
     }
 
-    fun getStartSchedules(today: LocalDate) = schedules.value.filter { schedule ->
-        // TODO: 정렬
-        val isStart = schedule.startDate.toLocalDate() == today
-        val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
-        val isFirstOfMonth = today.dayOfMonth == 1
-        val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
-        isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
-    }
-
     fun getTodayItemIndex(): Int {
         val today = LocalDate.now()
 
@@ -56,16 +49,12 @@ class YearCalendarViewModel: ViewModel() {
     }
 
     fun setWeekSchedules(
-        todaySchedules: List<CalendarScheduleObject>,
         weekSchedules: Array<Array<CalendarScheduleObject?>>,
         today: LocalDate
     ) {
         val todayOfWeek = today.dayOfWeek.dayValue()
 
-        // 오늘 스케줄 3개.forEach()
-        // weekSchedules 빈자리 찾으면 endDate 까지 그자리 차지
-        // 근데 왜 return@forEach??
-        todaySchedules.forEach { todaySchedule ->
+        getStartSchedules(today).forEach { todaySchedule ->
             val weekEndDate =
                 if (!today.isSameWeek(todaySchedule.endDate.toLocalDate())) DayOfWeek.SATURDAY.value
                 else todaySchedule.endDate.dayOfWeek.dayValue()
@@ -80,6 +69,20 @@ class YearCalendarViewModel: ViewModel() {
             }
         }
     }
+
+    private fun getStartSchedules(today: LocalDate) = schedules.value.filter { schedule ->
+        // TODO: 정렬
+        val isStart = schedule.startDate.toLocalDate() == today
+        val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
+        val isFirstOfMonth = today.dayOfMonth == 1
+        val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
+        isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
+    }
+
+    fun isFirstWeek(week: List<CalendarDate>, monthId: Int) = week.any { day ->
+        day.date.dayOfMonth == 1 && monthId == day.date.monthValue
+    }
+
 
     companion object {
         const val INIT_YEAR = 0

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -2,8 +2,10 @@ package com.drunkenboys.ckscalendar.yearcalendar
 
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
+import com.drunkenboys.ckscalendar.FakeFactory
 import com.drunkenboys.ckscalendar.data.CalendarDesignObject
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
+import com.drunkenboys.ckscalendar.data.CalendarSet
 
 class YearCalendarViewModel: ViewModel() {
 
@@ -12,6 +14,11 @@ class YearCalendarViewModel: ViewModel() {
 
     private val _design = mutableStateOf(CalendarDesignObject())
     val design: State<CalendarDesignObject> = _design
+
+    private val _yearList = (YearCalendarView.INIT_YEAR..YearCalendarView.LAST_YEAR).map { year ->
+        FakeFactory.createFakeCalendarSetList(year)
+    }
+    val yearList: List<List<CalendarSet>> = _yearList
 
     fun setSchedule(schedule: CalendarScheduleObject) {
         this._schedules.value = this.schedules.value.plus(schedule)

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -1,6 +1,5 @@
 package com.drunkenboys.ckscalendar.yearcalendar
 
-import android.util.Log
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.drunkenboys.ckscalendar.FakeFactory
@@ -25,12 +24,20 @@ class YearCalendarViewModel: ViewModel() {
         FakeFactory.createFakeCalendarSetList(year)
     }
 
+    private var recomposeScope: RecomposeScope? = null
+
+    fun setRecomposeScope(recompose: RecomposeScope) {
+        this.recomposeScope = recompose
+    }
+
     fun setSchedule(schedule: CalendarScheduleObject) {
         this._schedules.value = this.schedules.value.plus(schedule)
+        recomposeScope?.invalidate()
     }
 
     fun setSchedules(schedules: List<CalendarScheduleObject>) {
         this._schedules.value = schedules
+        recomposeScope?.invalidate()
     }
 
     fun setDesign(design: CalendarDesignObject) {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -6,6 +6,8 @@ import com.drunkenboys.ckscalendar.FakeFactory
 import com.drunkenboys.ckscalendar.data.CalendarDesignObject
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.data.CalendarSet
+import java.time.DayOfWeek
+import java.time.LocalDate
 
 class YearCalendarViewModel: ViewModel() {
 
@@ -15,10 +17,9 @@ class YearCalendarViewModel: ViewModel() {
     private val _design = mutableStateOf(CalendarDesignObject())
     val design: State<CalendarDesignObject> = _design
 
-    private val _yearList = (YearCalendarView.INIT_YEAR..YearCalendarView.LAST_YEAR).map { year ->
+    val yearList: List<List<CalendarSet>> = (INIT_YEAR..LAST_YEAR).map { year ->
         FakeFactory.createFakeCalendarSetList(year)
     }
-    val yearList: List<List<CalendarSet>> = _yearList
 
     fun setSchedule(schedule: CalendarScheduleObject) {
         this._schedules.value = this.schedules.value.plus(schedule)
@@ -34,5 +35,26 @@ class YearCalendarViewModel: ViewModel() {
 
     fun resetDesign() {
         _design.value = CalendarDesignObject()
+    }
+
+    fun getStartSchedules(today: LocalDate) = schedules.value.filter { schedule ->
+        // TODO: 정렬
+        val isStart = schedule.startDate.toLocalDate() == today
+        val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
+        val isFirstOfMonth = today.dayOfMonth == 1
+        val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
+        isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
+    }
+
+    fun getTodayItemIndex(): Int {
+        val today = LocalDate.now()
+
+        // (월 달력 12개 + 년 헤더 1개) + 이번달
+        return (today.year - INIT_YEAR) * 13 + today.monthValue
+    }
+
+    companion object {
+        const val INIT_YEAR = 0
+        const val LAST_YEAR = 10000
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -6,6 +6,8 @@ import com.drunkenboys.ckscalendar.FakeFactory
 import com.drunkenboys.ckscalendar.data.CalendarDesignObject
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.data.CalendarSet
+import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
+import com.drunkenboys.ckscalendar.utils.TimeUtils.isSameWeek
 import java.time.DayOfWeek
 import java.time.LocalDate
 
@@ -51,6 +53,32 @@ class YearCalendarViewModel: ViewModel() {
 
         // (월 달력 12개 + 년 헤더 1개) + 이번달
         return (today.year - INIT_YEAR) * 13 + today.monthValue
+    }
+
+    fun setWeekSchedules(
+        todaySchedules: List<CalendarScheduleObject>,
+        weekSchedules: Array<Array<CalendarScheduleObject?>>,
+        today: LocalDate
+    ) {
+        val todayOfWeek = today.dayOfWeek.dayValue()
+
+        // 오늘 스케줄 3개.forEach()
+        // weekSchedules 빈자리 찾으면 endDate 까지 그자리 차지
+        // 근데 왜 return@forEach??
+        todaySchedules.forEach { todaySchedule ->
+            val weekEndDate =
+                if (!today.isSameWeek(todaySchedule.endDate.toLocalDate())) DayOfWeek.SATURDAY.value
+                else todaySchedule.endDate.dayOfWeek.dayValue()
+
+            weekSchedules[todayOfWeek].forEachIndexed { index, space ->
+                if (space == null) {
+                    (todayOfWeek..weekEndDate).forEach { weekNum ->
+                        weekSchedules[weekNum][index] = todaySchedule
+                    }
+                    return@forEach
+                }
+            }
+        }
     }
 
     companion object {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -55,7 +55,7 @@ fun CalendarLazyColumn(
 
     // RecyclerView와 유사
     LazyColumn(state = listState) {
-        yearList.forEach { year ->
+        viewModel.yearList.forEach { year ->
             // 달력
             item {
                 Text(
@@ -84,10 +84,6 @@ fun CalendarLazyColumn(
         listState.scrollToItem(index = YearCalendarView.LAST_YEAR - 1) // preload
         listState.scrollToItem(index = getTodayItemIndex())
     }
-}
-
-private val yearList = (YearCalendarView.INIT_YEAR..YearCalendarView.LAST_YEAR).map { year ->
-    FakeFactory.createFakeCalendarSetList(year)
 }
 
 private fun getTodayItemIndex(): Int {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -16,12 +16,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.drunkenboys.ckscalendar.FakeFactory
 import com.drunkenboys.ckscalendar.data.*
 import com.drunkenboys.ckscalendar.listener.OnDayClickListener
 import com.drunkenboys.ckscalendar.listener.OnDaySecondClickListener
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
-import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarView
 import java.time.LocalDate
 
 @Composable
@@ -42,6 +40,10 @@ fun CalendarLazyColumn(
         )
     }
 
+    // viewModel의 recomposer를 LazyColumn으로 설정해서 setSchedule 호출 시 recompose
+    viewModel.setRecomposeScope(currentRecomposeScope)
+
+    // state hoisting
     val dayColumnModifier = { day: CalendarDate ->
         Modifier
             .layoutId(day.date.toString())

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -81,14 +81,7 @@ fun CalendarLazyColumn(
 
     // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
     LaunchedEffect(listState) {
-        listState.scrollToItem(index = YearCalendarView.LAST_YEAR - 1) // preload
-        listState.scrollToItem(index = getTodayItemIndex())
+        listState.scrollToItem(index = YearCalendarViewModel.LAST_YEAR) // preload
+        listState.scrollToItem(index = viewModel.getTodayItemIndex())
     }
-}
-
-private fun getTodayItemIndex(): Int {
-    val today = LocalDate.now()
-
-    // (월 달력 12개 + 년 헤더 1개) + 이번달
-    return (today.year - YearCalendarView.INIT_YEAR) * 13 + today.monthValue
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
@@ -32,33 +32,23 @@ fun MonthCalendar(
         ) {
             weekSchedules = Array(7) { Array(viewModel.design.value.visibleScheduleCount) { null } }
             // 월 표시
-            if (isFirstWeek(week, month.id)) {
-                AnimatedMonthHeader(
-                    listState = listState,
-                    month = month.id
-                )
-            }
+            if (viewModel.isFirstWeek(week, month.id))
+                AnimatedMonthHeader(listState = listState, month = month.id)
+
             week.forEach { day ->
                 when (day.dayType) {
                     // 빈 날짜
-                    DayType.PADDING -> {
-                        PaddingText(day = day, viewModel = viewModel)
-                    }
+                    DayType.PADDING -> PaddingText(day = day, viewModel = viewModel)
+
                     // 1일
-                    else -> {
-                        Column(modifier = dayColumnModifier(day), horizontalAlignment = Alignment.CenterHorizontally) {
-                            DayText(day = day, viewModel = viewModel)
-                            ScheduleText(today = day.date, weekSchedules, viewModel = viewModel)
-                        }
+                    else -> Column(modifier = dayColumnModifier(day), horizontalAlignment = Alignment.CenterHorizontally) {
+                        DayText(day = day, viewModel = viewModel)
+                        ScheduleText(today = day.date, weekSchedules, viewModel = viewModel)
                     }
                 }
             }
         }
     }
-}
-
-private fun isFirstWeek(week: List<CalendarDate>, monthId: Int) = week.any { day ->
-    day.date.dayOfMonth == 1 && monthId == day.date.monthValue
 }
 
 private fun dayOfWeekConstraints(weekIds: List<String>) = ConstraintSet {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -38,9 +38,7 @@ fun ScheduleText(
         if (schedule != null) Color(schedule.color) else Color.Transparent
     }
 
-    val startSchedules = viewModel.getStartSchedules(today)
-
-    viewModel.setWeekSchedules(startSchedules, weekScheduleList, today)
+    viewModel.setWeekSchedules(weekScheduleList, today)
 
     weekScheduleList[weekNum].forEach { schedule ->
         Text(

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
-import com.drunkenboys.ckscalendar.utils.TimeUtils.isSameWeek
 import com.drunkenboys.ckscalendar.utils.dp
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 import java.time.DayOfWeek

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -38,7 +38,9 @@ fun ScheduleText(
         if (schedule != null) Color(schedule.color) else Color.Transparent
     }
 
-    setWeekSchedules(getStartScheduleList(today, viewModel.schedules.value), weekScheduleList, today)
+    val startSchedules = viewModel.getStartSchedules(today)
+
+    setWeekSchedules(startSchedules, weekScheduleList, today)
 
     weekScheduleList[weekNum].forEach { schedule ->
         Text(
@@ -62,32 +64,21 @@ private fun setWeekSchedules(
 ) {
     val todayOfWeek = today.dayOfWeek.dayValue()
 
+    // 오늘 스케줄 3개.forEach()
+    // weekSchedules 빈자리 찾으면 endDate 까지 그자리 차지
+    // 근데 왜 return@forEach??
     todaySchedules.forEach { todaySchedule ->
         val weekEndDate =
             if (!today.isSameWeek(todaySchedule.endDate.toLocalDate())) DayOfWeek.SATURDAY.value
             else todaySchedule.endDate.dayOfWeek.dayValue()
 
         weekSchedules[todayOfWeek].forEachIndexed { index, space ->
-            when (space) {
-                todaySchedule -> {
-                    return@forEach
+            if (space == null) {
+                (todayOfWeek..weekEndDate).forEach { weekNum ->
+                    weekSchedules[weekNum][index] = todaySchedule
                 }
-                null -> {
-                    (todayOfWeek..weekEndDate).forEach { weekNum ->
-                        weekSchedules[weekNum][index] = todaySchedule
-                    }
-                    return@forEach
-                }
+                return@forEach
             }
         }
     }
-}
-
-private fun getStartScheduleList(today: LocalDate, schedules: List<CalendarScheduleObject>) = schedules.filter { schedule ->
-    // TODO: 정렬
-    val isStart = schedule.startDate.toLocalDate() == today
-    val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
-    val isFirstOfMonth = today.dayOfMonth == 1
-    val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
-    isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -40,7 +40,7 @@ fun ScheduleText(
 
     val startSchedules = viewModel.getStartSchedules(today)
 
-    setWeekSchedules(startSchedules, weekScheduleList, today)
+    viewModel.setWeekSchedules(startSchedules, weekScheduleList, today)
 
     weekScheduleList[weekNum].forEach { schedule ->
         Text(
@@ -54,31 +54,5 @@ fun ScheduleText(
             color = Color.White
         )
         Spacer(modifier = Modifier.height(2.dp))
-    }
-}
-
-private fun setWeekSchedules(
-    todaySchedules: List<CalendarScheduleObject>,
-    weekSchedules: Array<Array<CalendarScheduleObject?>>,
-    today: LocalDate
-) {
-    val todayOfWeek = today.dayOfWeek.dayValue()
-
-    // 오늘 스케줄 3개.forEach()
-    // weekSchedules 빈자리 찾으면 endDate 까지 그자리 차지
-    // 근데 왜 return@forEach??
-    todaySchedules.forEach { todaySchedule ->
-        val weekEndDate =
-            if (!today.isSameWeek(todaySchedule.endDate.toLocalDate())) DayOfWeek.SATURDAY.value
-            else todaySchedule.endDate.dayOfWeek.dayValue()
-
-        weekSchedules[todayOfWeek].forEachIndexed { index, space ->
-            if (space == null) {
-                (todayOfWeek..weekEndDate).forEach { weekNum ->
-                    weekSchedules[weekNum][index] = todaySchedule
-                }
-                return@forEach
-            }
-        }
     }
 }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #142 

## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 로직을 대부분 viewModel로 이전
- 스케줄을 추가해도 즉시 반영이 안되는 버그:
  - viewModel에 recompose Scope를 추가해 setSchedule을 호출할 때마다 뷰 전체를 새로고침
- 스케줄 추가 시 3중첩 추가 버그: 
  - 스케줄을 뷰에 보여주는 로직에서 return의 탈출 장소를 잘못 지정했던 문제였음