### PR TITLE
체크 포인트가 제대로 동작안하는 버그 수정

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -94,6 +94,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
                 // TODO: 2021-11-11 테마 설정 화면으로 이동
                 val action = MainCalendarFragmentDirections.toThemeFragment()
                 navController.navigate(action)
+                binding.layoutDrawer.closeDrawer(GravityCompat.START)
                 true
             }
     }
@@ -119,7 +120,13 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
     private fun collectCalendarSet() {
         stateCollect(mainCalendarViewModel.calendarSetList) { calendarSetList ->
-            binding.calendarMonth.setCalendarSetList(calendarSetList)
+            if (calendarSetList.isEmpty()) return@stateCollect
+
+            if (calendarSetList.firstOrNull()?.id == 1) { // CalendarSet 기본캘린더 ID에 대한 Unique 값이 필요함
+                binding.calendarMonth.setupDefaultCalendarSet()
+            } else {
+                binding.calendarMonth.setCalendarSetList(calendarSetList)
+            }
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -9,16 +9,12 @@ import com.drunkenboys.calendarun.data.checkpoint.entity.CheckPoint
 import com.drunkenboys.calendarun.data.checkpoint.local.CheckPointLocalDataSource
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
-import com.drunkenboys.calendarun.util.nextDay
 import com.drunkenboys.calendarun.ui.theme.toCalendarDesignObject
+import com.drunkenboys.calendarun.util.nextDay
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.data.CalendarSet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
@@ -60,7 +56,7 @@ class MainCalendarViewModel @Inject constructor(
             _calendar.emit(calendar)
             fetchCheckPointList(calendar.id).join()
             fetchScheduleList(calendar.id)
-            createCalendarSetList()
+            createCalendarSetList(calendar.id)
         }
     }
 
@@ -110,7 +106,7 @@ class MainCalendarViewModel @Inject constructor(
         }
     }
 
-    private fun createCalendarSetList() {
+    private fun createCalendarSetList(id: Long) {
         viewModelScope.launch {
             val calendarNameList = createCalendarSetNameList() ?: return@launch
             val calendarDateList = createCalendarSetDateList() ?: return@launch
@@ -121,7 +117,7 @@ class MainCalendarViewModel @Inject constructor(
             for (i in calendarNameList.indices) {
                 calendarSetList.add(
                     CalendarSet(
-                        id = i,
+                        id = id.toInt(), // CalendarSet 기본캘린더 ID에 대한 Unique 값이 필요함
                         name = calendarNameList[i],
                         startDate = calendarStartDateList[i],
                         endDate = calendarEndDateList[i]
@@ -160,7 +156,7 @@ class MainCalendarViewModel @Inject constructor(
 
         return calendarStartDateList to calendarEndDateList
     }
-    
+
     fun fetchCalendarDesignObject() = calendarThemeDataSource.fetchCalendarTheme()
         .map { it.toCalendarDesignObject() }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 21
         targetSdk 31
         versionCode 1
-        versionName "0.0.1"
+        versionName "0.0.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -90,7 +90,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.boostcampwm-2021'
                 artifactId = 'android01-CalendaRun'
-                version = '0.0.1'
+                version = '0.0.3'
             }
         }
     }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCalendarView.kt
@@ -69,12 +69,6 @@ class MonthCalendarView @JvmOverloads constructor(
         binding.vpMonthPage.registerOnPageChangeCallback(onPageChange)
 
         setupDefaultCalendarSet()
-        calendarList.forEachIndexed { index, calendarSet ->
-            if (calendarSet.startDate.monthValue == today.monthValue) {
-                binding.vpMonthPage.setCurrentItem(Int.MAX_VALUE / 2 + index, false)
-                return@forEachIndexed
-            }
-        }
 
         // xml에서 넘어온 attribute 값 적용
         val attr = context.obtainStyledAttributes(attrs, R.styleable.MonthCalendarView)
@@ -100,19 +94,22 @@ class MonthCalendarView @JvmOverloads constructor(
         }
     }
 
-    private fun initAttribute() {
-
-    }
-
     fun setCalendarSetList(calendarList: List<CalendarSet>) {
         this.calendarList = calendarList
         pageAdapter.setItems(calendarList, false)
+        binding.tvMonthCalendarViewCurrentMonth.text = calendarList.first().name
     }
 
     fun setupDefaultCalendarSet() {
         calendarList = CalendarSet.generateCalendarOfYear(context, today.year)
         pageAdapter.setItems(calendarList, true)
-        binding.vpMonthPage.setCurrentItem(Int.MAX_VALUE / 2, false)
+        
+        calendarList.forEachIndexed { index, calendarSet -> //오늘 날짜로 이동
+            if (calendarSet.startDate.monthValue == today.monthValue) {
+                binding.vpMonthPage.setCurrentItem(Int.MAX_VALUE / 2 + index, false)
+                return@forEachIndexed
+            }
+        }
     }
 
     fun setOnDayClickListener(onDayClickListener: OnDayClickListener) {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCalendarView.kt
@@ -103,9 +103,10 @@ class MonthCalendarView @JvmOverloads constructor(
     fun setupDefaultCalendarSet() {
         calendarList = CalendarSet.generateCalendarOfYear(context, today.year)
         pageAdapter.setItems(calendarList, true)
-        
+
         calendarList.forEachIndexed { index, calendarSet -> //오늘 날짜로 이동
             if (calendarSet.startDate.monthValue == today.monthValue) {
+                binding.tvMonthCalendarViewCurrentMonth.text = calendarSet.name
                 binding.vpMonthPage.setCurrentItem(Int.MAX_VALUE / 2 + index, false)
                 return@forEachIndexed
             }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCellFactory.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/month/MonthCellFactory.kt
@@ -23,11 +23,19 @@ class MonthCellFactory {
                     }
 
                     // add Start Dates
-                    dates.addAll(makeDates(item.startDate, month))
+                    if (startMonth == endMonth) {
+                        dates.addAll(makeDates(item.startDate.dayOfMonth, item.endDate.dayOfMonth, month, item.startDate.year))
+                    } else {
+                        dates.addAll(makeDates(item.startDate.dayOfMonth, item.startDate.lengthOfMonth(), month, item.startDate.year))
+                    }
+                }
+                endMonth -> {
+                    dates.addAll(makeDates(1, item.endDate.dayOfMonth, month, item.endDate.year))
                 }
                 else -> {
                     // add Normal Dates
-                    dates.addAll(makeDates(item.endDate, month))
+                    val monthDate = LocalDate.of(item.endDate.year, month, 1)
+                    dates.addAll(makeDates(1, monthDate.lengthOfMonth(), month, monthDate.year))
                 }
             }
         }
@@ -44,10 +52,9 @@ class MonthCellFactory {
         return dates
     }
 
-    private fun makeDates(selectedDate: LocalDate, month: Int): List<CalendarDate> {
-        val monthDate = LocalDate.of(selectedDate.year, month, 1)
-        return (1..monthDate.lengthOfMonth()).map { day ->
-            val date = LocalDate.of(selectedDate.year, month, day)
+    private fun makeDates(startDay: Int, endDay: Int, month: Int, year: Int): List<CalendarDate> {
+        return (startDay..endDay).map { day ->
+            val date = LocalDate.of(year, month, day)
             val dayType = TimeUtils.parseDayWeekToDayType(date.dayOfWeek)
             CalendarDate(date, dayType)
         }
@@ -59,7 +66,7 @@ class MonthCellFactory {
         }
     }
 
-    companion object{
+    companion object {
 
         private const val WEEK_SIZE = 7
         private const val CALENDAR_FULL_SIZE = 42


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolved: #187 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 체크포인트 버그 수정 

  체크포인트 달력 생성시 시작일은 1일, 종료일은 29,30,31 일때의 기준으로 작성되어 의도한대로 동작하지 않아 이에대한 수정
- 달력 전환이 제대로 안되는 버그 수정

  앱 실행시 빈리스트를 반환해 이에 대한 예외처리, 기본 캘린더를 초기값으로 설정하게 되는데 기본캘린더와 개인 달력의 구분을 위한 id가 구분되어 있지 않아 임시로 1번을 지정함 기본 달력에 대한 CalendarSet Id가 유니크 하도록 수정이 필요함

- 라이브러리 버전 0.0.3으로 변경

