### PR TITLE
일정의 제목이 비어있을 때 에러 가이드 추가

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleFragment.kt
@@ -46,6 +46,7 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         collectIsPickTagColorPopupVisible()
         collectSaveScheduleEvent()
         collectDeleteScheduleEvent()
+        collectBlankTitleEvent()
     }
 
     private fun setupToolbar() = with(binding) {
@@ -180,5 +181,11 @@ class SaveScheduleFragment : BaseFragment<FragmentSaveScheduleBinding>(R.layout.
         val alarmManager = requireContext().getSystemService<AlarmManager>() ?: return
 
         alarmManager.cancel(ScheduleAlarmReceiver.createPendingIntent(requireContext(), schedule))
+    }
+
+    private fun collectBlankTitleEvent() {
+        sharedCollect(saveScheduleViewModel.blankTitleEvent) {
+            binding.etSaveScheduleTitleInput.isError = true
+        }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/saveschedule/SaveScheduleViewModel.kt
@@ -70,6 +70,9 @@ class SaveScheduleViewModel @Inject constructor(
     private val _deleteScheduleEvent = MutableSharedFlow<Schedule>()
     val deleteScheduleEvent: SharedFlow<Schedule> = _deleteScheduleEvent
 
+    private val _blankTitleEvent = MutableSharedFlow<Unit>()
+    val blankTitleEvent: SharedFlow<Unit> = _blankTitleEvent
+
     init {
         restoreScheduleData()
     }
@@ -146,9 +149,12 @@ class SaveScheduleViewModel @Inject constructor(
     }
 
     fun saveSchedule() {
-        if (isInvalidInput()) return
-
         viewModelScope.launch {
+            if (title.value.isBlank()) {
+                _blankTitleEvent.emit(Unit)
+                return@launch
+            }
+
             val schedule = createScheduleInstance()
 
             if (isUpdateSchedule) {
@@ -159,13 +165,6 @@ class SaveScheduleViewModel @Inject constructor(
                 _saveScheduleEvent.emit(schedule.copy(id = rowId))
             }
         }
-    }
-
-    private fun isInvalidInput(): Boolean {
-        if (title.value.isEmpty()) return true
-        if (calendarName.value.isEmpty()) return true
-
-        return false
     }
 
     private fun createScheduleInstance() = Schedule(

--- a/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
@@ -18,7 +18,7 @@ class ErrorGuideEditText @JvmOverloads constructor(
 ) : AppCompatEditText(context, attrs, defStyle) {
 
     private val defaultHintTextColor = currentHintTextColor
-    private val errorColor = ContextCompat.getColor(context, R.color.dark_pink)
+    private val errorColor = ContextCompat.getColor(context, R.color.onError)
 
     var isError = false
         set(value) {

--- a/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
@@ -56,13 +56,14 @@ class ErrorGuideEditText @JvmOverloads constructor(
         )
 
         AnimatorSet().apply {
-            duration = 300
+            duration = DURATION
             play(hintTextColorAnimator).with(translationAnimator)
         }.start()
     }
 
     companion object {
 
+        private const val DURATION = 300L
         private const val HINT_TEXT_COLOR = "hintTextColor"
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideEditText.kt
@@ -1,0 +1,68 @@
+package com.drunkenboys.calendarun.view
+
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.content.ContextCompat
+import androidx.core.widget.doOnTextChanged
+import com.drunkenboys.calendarun.R
+import com.drunkenboys.calendarun.util.extensions.dp2px
+
+class ErrorGuideEditText @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = R.attr.editTextStyle
+) : AppCompatEditText(context, attrs, defStyle) {
+
+    private val defaultHintTextColor = currentHintTextColor
+    private val errorColor = ContextCompat.getColor(context, R.color.dark_pink)
+
+    var isError = false
+        set(value) {
+            if (value) startErrorAnimation()
+            field = value
+        }
+
+    init {
+        doOnTextChanged { _, _, _, _ ->
+            if (isError) {
+                setHintTextColor(defaultHintTextColor)
+                isError = false
+            }
+        }
+    }
+
+    private fun startErrorAnimation() {
+        val leftTranslationX = context.dp2px(-2f)
+        val rightTranslationX = context.dp2px(2f)
+
+        val hintTextColorAnimator = ObjectAnimator.ofArgb(
+            this,
+            HINT_TEXT_COLOR,
+            currentHintTextColor,
+            errorColor
+        )
+        val translationAnimator = ObjectAnimator.ofFloat(
+            this,
+            View.TRANSLATION_X,
+            rightTranslationX,
+            leftTranslationX,
+            rightTranslationX,
+            leftTranslationX,
+            0f
+        )
+
+        AnimatorSet().apply {
+            duration = 300
+            play(hintTextColorAnimator).with(translationAnimator)
+        }.start()
+    }
+
+    companion object {
+
+        private const val HINT_TEXT_COLOR = "hintTextColor"
+    }
+}

--- a/app/src/main/res/layout/fragment_save_schedule.xml
+++ b/app/src/main/res/layout/fragment_save_schedule.xml
@@ -44,7 +44,7 @@
                 android:layout_height="wrap_content"
                 android:paddingHorizontal="16dp">
 
-                <EditText
+                <com.drunkenboys.calendarun.view.ErrorGuideEditText
                     android:id="@+id/et_saveSchedule_titleInput"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,6 @@
     <color name="dark_grey">#4D4D4D</color>
     <color name="light_pink">#FBC4FF</color>
     <color name="dark_pink">#FB60C4</color>
+
+    <color name="onError">#e20000</color>
 </resources>


### PR DESCRIPTION
## what is this pr

Resolve: #205 

## Changes
- ErrorGuidEditText 추가
- 저장 요청에서 일정 제목이 비어있다면 에러 표시

## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/52354794/142796456-66fb7b50-6655-4bfb-9986-202a83457da7.gif" width=350 />