### PR TITLE
Flow 확장함수 리팩터링

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
@@ -9,9 +9,10 @@ import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.FragmentSearchScheduleBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
 import com.drunkenboys.calendarun.util.HorizontalInsetDividerDecoration
-import com.drunkenboys.calendarun.util.extensions.sharedCollect
-import com.drunkenboys.calendarun.util.extensions.stateCollect
+import com.drunkenboys.calendarun.util.extensions.launchAndRepeatWithViewLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.layout.fragment_search_schedule) {
@@ -26,8 +27,11 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
 
         setupToolbar()
         setupRecyclerView()
-        collectListItem()
-        collectScheduleClickEvent()
+
+        launchAndRepeatWithViewLifecycle {
+            launch { collectListItem() }
+            launch { collectScheduleClickEvent() }
+        }
 
         searchScheduleViewModel.fetchScheduleList()
     }
@@ -48,14 +52,14 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
         binding.rvSearchSchedule.addItemDecoration(itemDecoration)
     }
 
-    private fun collectListItem() {
-        stateCollect(searchScheduleViewModel.listItem) { listItem ->
+    private suspend fun collectListItem() {
+        searchScheduleViewModel.listItem.collect { listItem ->
             searchScheduleAdapter.submitList(listItem)
         }
     }
 
-    private fun collectScheduleClickEvent() {
-        sharedCollect(searchScheduleViewModel.scheduleClickEvent) { schedule ->
+    private suspend fun collectScheduleClickEvent() {
+        searchScheduleViewModel.scheduleClickEvent.collect { schedule ->
             val action = SearchScheduleFragmentDirections.toSaveSchedule(schedule.calendarId, schedule.id)
             navController.navigate(action)
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/util/extensions/FragmentExt.kt
@@ -10,6 +10,7 @@ import com.drunkenboys.calendarun.util.toSecondLong
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
@@ -70,6 +71,18 @@ inline fun <T> Fragment.sharedCollect(sharedFlow: SharedFlow<T>, crossinline blo
     viewLifecycleOwner.lifecycleScope.launch {
         sharedFlow.collectLatest {
             block(it)
+        }
+    }
+}
+
+// from iosched(https://github.com/google/iosched)
+inline fun Fragment.launchAndRepeatWithViewLifecycle(
+    state: Lifecycle.State = Lifecycle.State.STARTED,
+    crossinline block: suspend CoroutineScope.() -> Unit
+) {
+    viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner.lifecycle.repeatOnLifecycle(state) {
+            block()
         }
     }
 }


### PR DESCRIPTION
## what is this pr
개요: #167, [일반 flow를 sharedFlow 확장함수에 적용할 수 없음](https://github.com/boostcampwm-2021/android01-CalendaRun/pull/167#discussion_r750281244)

flow 스코프를 지정하는 확장함수를 변경하였는데 아직 flow를 사용하는 모든 곳이 변경되지는 않았습니다.
함수의 동작과 네이밍은 iosched를 참조했습니다.

iosched 에서는 아래 처럼 사용하는데 어떤 방식이 더 좋을까요?
```kotlin
override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
    ...

    launchAndRepeatWithViewLifecycle {
        observeViewModel()
    }
}

private fun CoroutineScope.observeViewModel() {
    val menu = binding.sessionDetailBottomAppBar.menu
    val starMenu = menu.findItem(R.id.menu_item_star)
    launch {
        sessionDetailViewModel.shouldShowStarInBottomNav.collect { showStar ->
            starMenu.isVisible = showStar
        }
    }

    launch {
        sessionDetailViewModel.userEvent.collect { userEvent ->
            userEvent?.let {
                if (it.isStarred) {
                    starMenu.setIcon(R.drawable.ic_star)
                } else {
                    starMenu.setIcon(R.drawable.ic_star_border)
                }
            }
        }
    }
    ...
}
```

괜찮은 방법이 있으면 선택해서 flow 사용하는곳에 적용하죠.

Resolve: #204

## Changes
- flow 확장함수 수정
- SearchScheduleFragment에 변경사항 적용.
