### PR TITLE
연달력 월표시 입체감 추가

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
@@ -3,8 +3,9 @@ package com.drunkenboys.ckscalendar.yearcalendar.composeView
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -29,20 +30,22 @@ fun AnimatedMonthHeader(
         )
     )
 
-    Text(
-        text = monthName,
-        color = MaterialTheme.colors.primary,
+    Card(
         modifier = Modifier
             .alpha(density)
             .padding(start = (density * 5).dp)
-    )
+    ) {
+        Text(
+            text = monthName,
+            color = MaterialTheme.colors.primary,
+        )
+    }
 }
 
 @Preview
 @Composable
 fun PreviewMonthHeader() {
     val viewModel = YearCalendarViewModel()
-
     CustomTheme(design = viewModel.design.value) {
         Text(
             text = "1월",

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
+import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 
 @Composable
 fun AnimatedMonthHeader(
@@ -39,9 +41,13 @@ fun AnimatedMonthHeader(
 @Preview
 @Composable
 fun PreviewMonthHeader() {
-    Text(
-        text = "1월",
-        color = MaterialTheme.colors.primary,
-        modifier = Modifier.padding(start = 5.dp)
-    )
+    val viewModel = YearCalendarViewModel()
+
+    CustomTheme(design = viewModel.design.value) {
+        Text(
+            text = "1월",
+            color = MaterialTheme.colors.primary,
+            modifier = Modifier.padding(start = 5.dp)
+        )
+    }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
@@ -3,13 +3,8 @@ package com.drunkenboys.ckscalendar.yearcalendar.composeView
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -17,12 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.drunkenboys.ckscalendar.R
 import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 
@@ -40,19 +31,19 @@ fun AnimatedMonthHeader(
     )
 
     Card(
-        modifier = Modifier
-            .alpha(density)
-            .padding(start = (density * 5).dp)
+        modifier = Modifier.alpha(density),
+        elevation = 10.dp
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.ic_main_background),
-            contentDescription = "월 아이콘", // FIXME strings.xml
-            modifier = Modifier.clip(shape = RoundedCornerShape(16.dp))
-        )
-
         Text(
             text = monthName,
             color = MaterialTheme.colors.primary,
+            modifier = Modifier
+                .padding(
+                    start = 20.dp,
+                    end = 20.dp,
+                    top = 5.dp,
+                    bottom = 5.dp
+                )
         )
     }
 }
@@ -62,17 +53,20 @@ fun AnimatedMonthHeader(
 fun PreviewMonthHeader() {
     val viewModel = YearCalendarViewModel()
     CustomTheme(design = viewModel.design.value) {
-        Card {
-            Image(
-                painter = painterResource(id = R.drawable.ic_main_background),
-                contentDescription = "월 아이콘", // FIXME strings.xml
-                modifier = Modifier.clip(shape = RoundedCornerShape(16.dp))
-            )
-
+        Card(
+            modifier = Modifier.wrapContentSize(),
+            elevation = 200.dp
+        ) {
             Text(
                 text = "1월",
                 color = MaterialTheme.colors.primary,
-                modifier = Modifier.padding(start = 5.dp)
+                modifier = Modifier
+                    .padding(
+                        start = 20.dp,
+                        end = 20.dp,
+                        top = 5.dp,
+                        bottom = 5.dp
+                    )
             )
         }
     }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
@@ -12,8 +12,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 
@@ -31,7 +33,9 @@ fun AnimatedMonthHeader(
     )
 
     Card(
-        modifier = Modifier.alpha(density),
+        modifier = Modifier
+            .alpha(density)
+            .zIndex(10f),
         elevation = 10.dp
     ) {
         Text(

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthHeader.kt
@@ -3,8 +3,13 @@ package com.drunkenboys.ckscalendar.yearcalendar.composeView
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -12,8 +17,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.drunkenboys.ckscalendar.R
 import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 
@@ -35,6 +44,12 @@ fun AnimatedMonthHeader(
             .alpha(density)
             .padding(start = (density * 5).dp)
     ) {
+        Image(
+            painter = painterResource(id = R.drawable.ic_main_background),
+            contentDescription = "월 아이콘", // FIXME strings.xml
+            modifier = Modifier.clip(shape = RoundedCornerShape(16.dp))
+        )
+
         Text(
             text = monthName,
             color = MaterialTheme.colors.primary,
@@ -47,10 +62,18 @@ fun AnimatedMonthHeader(
 fun PreviewMonthHeader() {
     val viewModel = YearCalendarViewModel()
     CustomTheme(design = viewModel.design.value) {
-        Text(
-            text = "1월",
-            color = MaterialTheme.colors.primary,
-            modifier = Modifier.padding(start = 5.dp)
-        )
+        Card {
+            Image(
+                painter = painterResource(id = R.drawable.ic_main_background),
+                contentDescription = "월 아이콘", // FIXME strings.xml
+                modifier = Modifier.clip(shape = RoundedCornerShape(16.dp))
+            )
+
+            Text(
+                text = "1월",
+                color = MaterialTheme.colors.primary,
+                modifier = Modifier.padding(start = 5.dp)
+            )
+        }
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/WeekHeader.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/WeekHeader.kt
@@ -9,7 +9,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import com.drunkenboys.ckscalendar.utils.GravityMapper
+import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 
 @Composable
@@ -29,5 +31,15 @@ fun WeekHeader(
                 textAlign = GravityMapper.toTextAlign(viewModel.design.value.textAlign)
             )
         }
+    }
+}
+
+@Preview
+@Composable
+fun PreviewWeekHeader() {
+    val viewModel = YearCalendarViewModel()
+
+    CustomTheme(design = viewModel.design.value) {
+        WeekHeader(viewModel = viewModel)
     }
 }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #211 

## Changes
- 이미지 추가 해봤는데 해상도나 커스텀 테마에 대응하면서 배경 이미지의 크기를 맞추기가 어려움.
- elevation 속성을 주고 패딩을 조절해서 라벨지처럼 보이게 변경
## screenshot
<img src="https://user-images.githubusercontent.com/55696672/142835912-f1c99895-e4b6-445e-88bf-e34b51db0443.png" width=350 />
