### PR TITLE
yearCalendar viewModel 테스트

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/WeekCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/WeekCalendarView.kt
@@ -85,11 +85,11 @@ class WeekCalendarView
         viewModel.setSchedules(schedules)
     }
 
-    fun setTheme(designObject: CalendarDesignObject) {
+    fun setDesign(designObject: CalendarDesignObject) {
         viewModel.setDesign(designObject)
     }
 
-    fun resetTheme() {
-        viewModel.resetDesign()
+    fun setDefaultDesign() {
+        viewModel.setDefaultDesign()
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -78,7 +78,7 @@ class YearCalendarView
     }
 
     fun resetTheme() {
-        viewModel.resetDesign()
+        viewModel.setDefaultDesign()
     }
 
     fun moveToDay(day: LocalDate) {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -13,6 +13,7 @@ import com.drunkenboys.ckscalendar.listener.OnDayClickListener
 import com.drunkenboys.ckscalendar.listener.OnDaySecondClickListener
 import com.drunkenboys.ckscalendar.yearcalendar.composeView.*
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @BindingMethods(
     value = [
@@ -88,7 +89,7 @@ class YearCalendarView
 
     fun findClickedDay(): LocalDate? = viewModel.clickedDay.value
 
-    fun getDaySchedules(day: LocalDate): List<CalendarScheduleObject> = viewModel.getDaySchedules(day)
+    fun getDaySchedules(day: LocalDateTime): List<CalendarScheduleObject> = viewModel.getDaySchedules(day)
 
     fun setCalendarSetList(calendarSetList: List<CalendarSet>) {
         viewModel.setCalendarSetList(calendarSetList)

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -7,6 +7,7 @@ import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
 import com.drunkenboys.ckscalendar.utils.TimeUtils.isSameWeek
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class YearCalendarViewModel: ViewModel() {
 
@@ -90,8 +91,8 @@ class YearCalendarViewModel: ViewModel() {
         _clickedDay.value = day.date
     }
 
-    fun getDaySchedules(day: LocalDate) = schedules.value.filter { schedule ->
-        day in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
+    fun getDaySchedules(day: LocalDateTime) = schedules.value.filter { schedule ->
+        day in schedule.startDate..schedule.endDate
     }
 
     fun fetchNextCalendarSet() {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -43,8 +43,8 @@ class YearCalendarViewModel: ViewModel() {
         _design.value = design
     }
 
-    fun resetDesign() {
-        _design.value = CalendarDesignObject()
+    fun setDefaultDesign() {
+        _design.value = CalendarDesignObject.getDefaultDesign()
     }
 
     // FIXME: 체크포인트 속에서 오늘의 날짜 찾기

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -140,7 +140,5 @@ class YearCalendarViewModel: ViewModel() {
 
         // 오늘 선택
         _clickedDay.value = LocalDate.now()
-
-        // TODO: 스크롤
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -89,7 +89,7 @@ fun CalendarLazyColumn(
         listState.scrollToItem(index = viewModel.getDayItemIndex())
     }
 
-    listState.ShouldNextScroll() {
+    listState.ShouldNextScroll {
         viewModel.fetchNextCalendarSet()
     }
 

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -104,12 +104,12 @@ class YearCalendarViewModelTest {
         // Given 기본 캘린더
         viewModel.setupDefaultCalendarSet()
 
-        // When 기원전 1000년까지 스크롤
+        // When 기원전 1년까지 스크롤
         repeat(today.year + 1) {
             viewModel.fetchPrevCalendarSet()
         }
 
-        // Then 캘린더 첫 인덱스가 마이너스 1000년
+        // Then 캘린더 첫 인덱스가 마이너스 1년
         val startDate = viewModel.calendar.value.first().startDate
         assertEquals(-1, startDate.year)
     }

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -93,32 +93,17 @@ class YearCalendarViewModelTest {
     }
 
     @Test
-    fun `0년 까지의 무한스크롤 테스트`() {
-        // Given 기본 캘린더
-        viewModel.setupDefaultCalendarSet()
-
-        // When 0년까지 스크롤
-        repeat(today.year) {
-            viewModel.fetchPrevCalendarSet()
-        }
-
-        // Then 캘린더의 첫 인덱스가 0년
-        val startDate = viewModel.calendar.value.first().startDate
-        assertEquals(0, startDate.year)
-    }
-
-    @Test
     fun `0년 이전의 무한스크롤 테스트`() {
         // Given 기본 캘린더
         viewModel.setupDefaultCalendarSet()
 
         // When 기원전 1000년까지 스크롤
-        repeat(today.year + 1000) {
+        repeat(today.year + 1) {
             viewModel.fetchPrevCalendarSet()
         }
 
         // Then 캘린더 첫 인덱스가 마이너스 1000년
         val startDate = viewModel.calendar.value.first().startDate
-        assertEquals(-1000, startDate.year)
+        assertEquals(-1, startDate.year)
     }
 }

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -2,22 +2,29 @@ package com.drunkenboys.ckscalendar.yearcalendar
 
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import org.junit.Assert.*
+import org.junit.Before
 
 import org.junit.Test
 import java.time.LocalDateTime
 
 class YearCalendarViewModelTest {
 
-    private val viewModel = YearCalendarViewModel()
+    private lateinit var viewModel: YearCalendarViewModel
     private val today = LocalDateTime.now()
-    private val fakeSchedules = (1..10).map { i ->
-        CalendarScheduleObject(
-            id = i,
-            color = viewModel.design.value.weekDayTextColor,
-            text = "$i",
-            startDate = today.minusDays(i.toLong()),
-            endDate = today.plusDays(i.toLong())
-        )
+    private lateinit var fakeSchedules: List<CalendarScheduleObject>
+
+    @Before
+    fun setUp() {
+        viewModel = YearCalendarViewModel()
+        fakeSchedules = (1..10).map { i ->
+            CalendarScheduleObject(
+                id = i,
+                color = viewModel.design.value.weekDayTextColor,
+                text = "$i",
+                startDate = today.minusDays(i.toLong()),
+                endDate = today.plusDays(i.toLong())
+            )
+        }
     }
 
     @Test

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -91,4 +91,34 @@ class YearCalendarViewModelTest {
         // Then 일정이 비어 있어야 한다.
         assertTrue(viewModel.schedules.value.isEmpty())
     }
+
+    @Test
+    fun `0년 까지의 무한스크롤 테스트`() {
+        // Given 기본 캘린더
+        viewModel.setupDefaultCalendarSet()
+
+        // When 0년까지 스크롤
+        repeat(today.year) {
+            viewModel.fetchPrevCalendarSet()
+        }
+
+        // Then 캘린더의 첫 인덱스가 0년
+        val startDate = viewModel.calendar.value.first().startDate
+        assertEquals(0, startDate.year)
+    }
+
+    @Test
+    fun `0년 이전의 무한스크롤 테스트`() {
+        // Given 기본 캘린더
+        viewModel.setupDefaultCalendarSet()
+
+        // When 기원전 1000년까지 스크롤
+        repeat(today.year + 1000) {
+            viewModel.fetchPrevCalendarSet()
+        }
+
+        // Then 캘린더 첫 인덱스가 마이너스 1000년
+        val startDate = viewModel.calendar.value.first().startDate
+        assertEquals(-1000, startDate.year)
+    }
 }

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -1,0 +1,40 @@
+package com.drunkenboys.ckscalendar.yearcalendar
+
+import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
+import org.junit.Assert.*
+import org.junit.Before
+
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class YearCalendarViewModelTest {
+
+    private val viewModel = YearCalendarViewModel()
+    private val today = LocalDateTime.now()
+    private val fakeSchedules = (1..10).map { i ->
+        CalendarScheduleObject(
+            id = i,
+            color = viewModel.design.value.weekDayTextColor,
+            text = "$i",
+            startDate = today.minusDays(i.toLong()),
+            endDate = today.plusDays(i.toLong())
+        )
+    }
+
+    @Test
+    fun `해당_날짜_일정들_찾기_테스트`() {
+        // Given 10 schedule
+        // And today
+        viewModel.setSchedules(fakeSchedules)
+
+        // When get today schedules
+        val findSchedules = viewModel.getDaySchedules(LocalDateTime.now())
+
+        // Then schedule size is 10
+        assertEquals(10, findSchedules.size)
+
+        // And all schedules include today
+        assertTrue(findSchedules.all { schedule -> today in schedule.startDate..schedule.endDate })
+    }
+}

--- a/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
+++ b/library/src/test/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModelTest.kt
@@ -2,10 +2,8 @@ package com.drunkenboys.ckscalendar.yearcalendar
 
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import org.junit.Assert.*
-import org.junit.Before
 
 import org.junit.Test
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 class YearCalendarViewModelTest {
@@ -23,18 +21,74 @@ class YearCalendarViewModelTest {
     }
 
     @Test
-    fun `해당_날짜_일정들_찾기_테스트`() {
-        // Given 10 schedule
-        // And today
+    fun `해당 날짜가 포함된 모든 일정 찾기 테스트`() {
+        // Given 오늘이 포함된 10개의 스케줄
         viewModel.setSchedules(fakeSchedules)
 
-        // When get today schedules
+        // When 해당 날짜의 일정을 모두 반환
         val findSchedules = viewModel.getDaySchedules(LocalDateTime.now())
 
-        // Then schedule size is 10
-        assertEquals(10, findSchedules.size)
+        // Then 탐색한 개수와 일정 개수가 일치해야 한다.
+        assertEquals(fakeSchedules.size, findSchedules.size)
 
-        // And all schedules include today
+        // And 탐색한 일정 모두 오늘이 포함된 일정이어야 한다.
         assertTrue(findSchedules.all { schedule -> today in schedule.startDate..schedule.endDate })
+    }
+
+    @Test
+    fun `해당 날짜 이전만 포함된 일정 탐색하지 않기 테스트`() {
+        // Given 오늘 날짜가 아닌 스케줄들
+        val notTodaySchedules = (2..100000).map { minusDay ->
+            CalendarScheduleObject(
+                id = minusDay,
+                color = 0,
+                text = "test",
+                startDate = today.minusDays(minusDay.toLong()),
+                endDate = today.minusDays(minusDay.toLong() - 1)
+            )
+        }
+
+        viewModel.setSchedules(notTodaySchedules)
+
+        // When 해당 날짜의 일정을 모두 반환
+        val findSchedules = viewModel.getDaySchedules(today)
+
+        // Then 빈 리스트가 반환돼야 한다.
+        assertTrue(findSchedules.isEmpty())
+    }
+
+    @Test
+    fun `오늘 하루짜리 일정 추가 시 오늘 일정 탐색 테스트`() {
+        // Given 오늘 시작하고 오늘 끝나는 일정
+        val oneDaySchedule = CalendarScheduleObject(
+            id = 0,
+            color = 0,
+            text = "",
+            startDate = today,
+            endDate = today
+        )
+
+        viewModel.setSchedule(oneDaySchedule)
+
+        // When 오늘의 일정을 모두 반환
+        val findSchedules = viewModel.getDaySchedules(today)
+
+        // Then 추가한 일정과 같은 일정이 반환돼야 한다.
+        assertEquals(oneDaySchedule, findSchedules[0])
+    }
+
+    @Test
+    fun `다수의 일정 추가 시 이전에 추가된 일정 제거 테스트`() {
+        // Given 이전 일정이 추가된 뷰모델
+        viewModel.setSchedules(fakeSchedules)
+
+        // And 빈 일정 배열
+        val newSchedules = listOf<CalendarScheduleObject>()
+
+        // When 빈 일정 배열을 추가
+        viewModel.setSchedules(newSchedules)
+
+        // Then 일정이 비어 있어야 한다.
+        assertTrue(viewModel.schedules.value.isEmpty())
     }
 }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #234

## Changes
- 원하는 날짜의 스케줄을 얻어오는 함수의 매개변수 데이터타입 수정
- 라이브러리 제공함수 네이밍 일부 수정
## TODO
- 기본 캘린더에만 무한스크롤이 들어가는데, 나도 기본 캘린더를 구분짓는 id가 필요했구나

## testchecklist
- 기원전 1000년까지 스크롤 테스트, -1000년이 존재 (10만년 했다가 컴퓨터 터질뻔함)
- 원하는 날짜의 일정 추가 & 탐색기능 테스트