### PR TITLE
기본 달력 추가 UX, 빈 입력 알려주는 UX 추가

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarAdapter.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarAdapter.kt
@@ -2,6 +2,7 @@ package com.drunkenboys.calendarun.ui.savecalendar
 
 import android.view.ViewGroup
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ListAdapter
 import com.drunkenboys.calendarun.BR
 import com.drunkenboys.calendarun.R
@@ -9,6 +10,9 @@ import com.drunkenboys.calendarun.databinding.ItemCheckPointBinding
 import com.drunkenboys.calendarun.ui.base.BaseViewHolder
 import com.drunkenboys.calendarun.ui.savecalendar.model.CheckPointItem
 import com.drunkenboys.calendarun.ui.saveschedule.model.DateType
+import com.drunkenboys.calendarun.view.ErrorGuideEditText
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class SaveCalendarAdapter(
     private val viewLifecycleOwner: LifecycleOwner,
@@ -23,6 +27,16 @@ class SaveCalendarAdapter(
             setVariable(BR.item, currentList[position])
             setVariable(BR.adapter, this@SaveCalendarAdapter)
             lifecycleOwner = viewLifecycleOwner
+
+            collectCalendarNameBlank(currentList[position], etCheckPointName)
+        }
+    }
+
+    private fun collectCalendarNameBlank(item: CheckPointItem, editText: ErrorGuideEditText) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            item.isBlank.collectLatest {
+                editText.isError = true
+            }
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarAdapter.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarAdapter.kt
@@ -11,6 +11,7 @@ import com.drunkenboys.calendarun.ui.base.BaseViewHolder
 import com.drunkenboys.calendarun.ui.savecalendar.model.CheckPointItem
 import com.drunkenboys.calendarun.ui.saveschedule.model.DateType
 import com.drunkenboys.calendarun.view.ErrorGuideEditText
+import com.drunkenboys.calendarun.view.ErrorGuideTextView
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
@@ -28,14 +29,33 @@ class SaveCalendarAdapter(
             setVariable(BR.adapter, this@SaveCalendarAdapter)
             lifecycleOwner = viewLifecycleOwner
 
-            collectCalendarNameBlank(currentList[position], etCheckPointName)
+            collectNameBlank(currentList[position], holder.binding.etCheckPointName)
+            collectStartBlank(currentList[position], holder.binding.tvCheckPointStartDatePicker)
+            collectEndBlank(currentList[position], holder.binding.tvCheckPointEndDatePicker)
         }
     }
 
-    private fun collectCalendarNameBlank(item: CheckPointItem, editText: ErrorGuideEditText) {
+    private fun collectNameBlank(item: CheckPointItem, view: ErrorGuideEditText) {
         viewLifecycleOwner.lifecycleScope.launch {
-            item.isBlank.collectLatest {
-                editText.isError = true
+            item.isNameBlank.collectLatest {
+                view.isError = true
+            }
+
+        }
+    }
+
+    private fun collectStartBlank(item: CheckPointItem, view: ErrorGuideTextView) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            item.isStartDateBlank.collectLatest {
+                view.isError = true
+            }
+        }
+    }
+
+    private fun collectEndBlank(item: CheckPointItem, view: ErrorGuideTextView) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            item.isEndDateBlank.collectLatest {
+                view.isError = true
             }
         }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
@@ -37,6 +37,7 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
         setupToolbarMenuOnItemClickListener()
         collectCheckPointItemList()
         collectSaveCalendarEvent()
+        collectUseDefaultCalendar()
     }
 
     private fun onCheckPointClick(checkPointItem: CheckPointItem, dateType: DateType) {
@@ -49,7 +50,6 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
                 DateType.START -> checkPointItem.startDate.emit(dateTime)
                 DateType.END -> checkPointItem.endDate.emit(dateTime)
             }
-
         }
     }
 
@@ -88,6 +88,21 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
             saveCalendarAdapter.submitList(list.sortedWith(compareBy(nullsFirst(reverseOrder())) { it.startDate.value }))
             delay(300)
             binding.svSaveCalendar.smoothScrollTo(0, binding.tvSaveCalendarSaveCalendar.bottom)
+        }
+    }
+
+    private fun collectUseDefaultCalendar() {
+        stateCollect(saveCalendarViewModel.useDefaultCalendar) { checked ->
+            when (checked) {
+                true -> {
+                    binding.rvSaveCalendarCheckPointList.visibility = View.GONE
+                    binding.tvSaveCalendarAddCheckPointView.visibility = View.GONE
+                }
+                false -> {
+                    binding.rvSaveCalendarCheckPointList.visibility = View.VISIBLE
+                    binding.tvSaveCalendarAddCheckPointView.visibility = View.VISIBLE
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
@@ -2,7 +2,6 @@ package com.drunkenboys.calendarun.ui.savecalendar
 
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
@@ -38,6 +37,7 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
         collectCheckPointItemList()
         collectSaveCalendarEvent()
         collectUseDefaultCalendar()
+        collectBlankTitleEvent()
     }
 
     private fun onCheckPointClick(checkPointItem: CheckPointItem, dateType: DateType) {
@@ -110,9 +110,13 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
         sharedCollect(saveCalendarViewModel.saveCalendarEvent) { isSaved ->
             if (isSaved) {
                 navController.navigateUp()
-            } else {
-                Toast.makeText(context, "입력 값이 이상해요", Toast.LENGTH_LONG).show()
             }
+        }
+    }
+
+    private fun collectBlankTitleEvent() {
+        sharedCollect(saveCalendarViewModel.blankTitleEvent) {
+            binding.etSaveCalendarCalendarName.isError = true
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarViewModel.kt
@@ -32,6 +32,8 @@ class SaveCalendarViewModel @Inject constructor(
 
     val calendarName = MutableStateFlow("")
 
+    val useDefaultCalendar = MutableStateFlow(false)
+
     private val _saveCalendarEvent = MutableSharedFlow<Boolean>()
     val saveCalendarEvent: SharedFlow<Boolean> = _saveCalendarEvent
 
@@ -80,9 +82,28 @@ class SaveCalendarViewModel @Inject constructor(
     }
 
     private fun saveCalendar(): Boolean {
+        val useDefaultCalendar = useDefaultCalendar.value
         val calendarName = calendarName.value
-        val checkPointList = _checkPointItemList.value
 
+        if (calendarName.isEmpty()) {
+            return false
+        }
+
+        if (useDefaultCalendar) {
+            viewModelScope.launch {
+                calendarLocalDataSource.insertCalendar(
+                    Calendar(
+                        id = calendarId,
+                        name = calendarName,
+                        startDate = LocalDate.now(),
+                        endDate = LocalDate.now()
+                    )
+                )
+            }
+            return true
+        }
+
+        val checkPointList = _checkPointItemList.value
         var calendarStartDate = checkPointList.getOrNull(0)?.startDate?.value ?: return false
         var calendarEndDate = checkPointList.getOrNull(0)?.endDate?.value ?: return false
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/model/CheckPointItem.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/model/CheckPointItem.kt
@@ -1,6 +1,7 @@
 package com.drunkenboys.calendarun.ui.savecalendar.model
 
 import androidx.recyclerview.widget.DiffUtil
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.LocalDate
 
@@ -9,12 +10,12 @@ data class CheckPointItem(
     val name: MutableStateFlow<String> = MutableStateFlow(""),
     val startDate: MutableStateFlow<LocalDate?> = MutableStateFlow(null),
     val endDate: MutableStateFlow<LocalDate?> = MutableStateFlow(null),
-    var check: Boolean = false
+    var check: Boolean = false,
+    val isBlank: MutableSharedFlow<Unit> = MutableSharedFlow(),
 ) : Comparable<CheckPointItem> {
 
     override fun compareTo(other: CheckPointItem): Int =
         compareValuesBy(this, other) { checkPoint -> checkPoint.startDate.value }
-
 
     companion object {
         val diffUtil by lazy {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/model/CheckPointItem.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/model/CheckPointItem.kt
@@ -11,7 +11,9 @@ data class CheckPointItem(
     val startDate: MutableStateFlow<LocalDate?> = MutableStateFlow(null),
     val endDate: MutableStateFlow<LocalDate?> = MutableStateFlow(null),
     var check: Boolean = false,
-    val isBlank: MutableSharedFlow<Unit> = MutableSharedFlow(),
+    val isNameBlank: MutableSharedFlow<Unit> = MutableSharedFlow(),
+    val isStartDateBlank: MutableSharedFlow<Unit> = MutableSharedFlow(),
+    val isEndDateBlank: MutableSharedFlow<Unit> = MutableSharedFlow()
 ) : Comparable<CheckPointItem> {
 
     override fun compareTo(other: CheckPointItem): Int =

--- a/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideTextView.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/view/ErrorGuideTextView.kt
@@ -1,0 +1,69 @@
+package com.drunkenboys.calendarun.view
+
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.ContextCompat
+import androidx.core.widget.doOnTextChanged
+import com.drunkenboys.calendarun.R
+import com.drunkenboys.calendarun.util.extensions.dp2px
+
+class ErrorGuideTextView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = R.attr.autoCompleteTextViewStyle
+) : AppCompatTextView(context, attrs, defStyle) {
+
+    private val defaultHintTextColor = currentHintTextColor
+    private val errorColor = ContextCompat.getColor(context, R.color.onError)
+
+    var isError = false
+        set(value) {
+            if (value) startErrorAnimation()
+            field = value
+        }
+
+    init {
+        doOnTextChanged { _, _, _, _ ->
+            if (isError) {
+                setHintTextColor(defaultHintTextColor)
+                isError = false
+            }
+        }
+    }
+
+    private fun startErrorAnimation() {
+        val leftTranslationX = context.dp2px(-2f)
+        val rightTranslationX = context.dp2px(2f)
+
+        val hintTextColorAnimator = ObjectAnimator.ofArgb(
+            this,
+            HINT_TEXT_COLOR,
+            currentHintTextColor,
+            errorColor
+        )
+        val translationAnimator = ObjectAnimator.ofFloat(
+            this,
+            View.TRANSLATION_X,
+            rightTranslationX,
+            leftTranslationX,
+            rightTranslationX,
+            leftTranslationX,
+            0f
+        )
+
+        AnimatorSet().apply {
+            duration = DURATION
+            play(hintTextColorAnimator).with(translationAnimator)
+        }.start()
+    }
+
+    companion object {
+
+        private const val DURATION = 300L
+        private const val HINT_TEXT_COLOR = "hintTextColor"
+    }
+}

--- a/app/src/main/res/layout/fragment_save_calendar.xml
+++ b/app/src/main/res/layout/fragment_save_calendar.xml
@@ -72,12 +72,12 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/tv_saveCalendar_calendarName" />
 
-                <EditText
+                <com.drunkenboys.calendarun.view.ErrorGuideEditText
                     android:id="@+id/et_saveCalendar_calendarName"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:ems="10"
+                    android:hint="@string/saveCalendar_title"
                     android:inputType="text"
                     android:text="@={saveCalendarViewModel.calendarName}"
                     app:layout_constraintEnd_toEndOf="@+id/switch_saveCalendar_defaultCalendar"

--- a/app/src/main/res/layout/fragment_save_calendar.xml
+++ b/app/src/main/res/layout/fragment_save_calendar.xml
@@ -57,9 +57,20 @@
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginTop="32dp"
                     android:text="@string/saveCalendar_title"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/switch_saveCalendar_defaultCalendar"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/switch_saveCalendar_defaultCalendar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:checked="@={saveCalendarViewModel.useDefaultCalendar}"
+                    android:text="@string/saveCalendar_defaultCalendar"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_saveCalendar_calendarName"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_saveCalendar_calendarName" />
 
                 <EditText
                     android:id="@+id/et_saveCalendar_calendarName"
@@ -69,7 +80,7 @@
                     android:ems="10"
                     android:inputType="text"
                     android:text="@={saveCalendarViewModel.calendarName}"
-                    app:layout_constraintEnd_toEndOf="@+id/tv_saveCalendar_calendarName"
+                    app:layout_constraintEnd_toEndOf="@+id/switch_saveCalendar_defaultCalendar"
                     app:layout_constraintStart_toStartOf="@id/tv_saveCalendar_calendarName"
                     app:layout_constraintTop_toBottomOf="@id/tv_saveCalendar_calendarName"
                     tools:text="수능 캘린더" />
@@ -81,7 +92,7 @@
                     android:nestedScrollingEnabled="false"
                     android:overScrollMode="never"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintEnd_toEndOf="@id/tv_saveCalendar_calendarName"
+                    app:layout_constraintEnd_toEndOf="@+id/switch_saveCalendar_defaultCalendar"
                     app:layout_constraintStart_toStartOf="@id/tv_saveCalendar_calendarName"
                     app:layout_constraintTop_toBottomOf="@+id/et_saveCalendar_calendarName"
                     app:reverseLayout="true"

--- a/app/src/main/res/layout/item_check_point.xml
+++ b/app/src/main/res/layout/item_check_point.xml
@@ -34,10 +34,12 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <EditText
+        <com.drunkenboys.calendarun.view.ErrorGuideEditText
             android:id="@+id/et_checkPoint_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:hint="@string/check_point_name"
+            android:inputType="text"
             android:text="@={item.name}"
             app:layout_constraintBottom_toBottomOf="@+id/tv_checkPoint_name"
             app:layout_constraintEnd_toEndOf="@+id/tv_checkPoint_startDatePicker"

--- a/app/src/main/res/layout/item_check_point.xml
+++ b/app/src/main/res/layout/item_check_point.xml
@@ -7,6 +7,8 @@
 
         <import type="com.drunkenboys.calendarun.util.DateConverterKt" />
 
+        <import type="java.time.LocalDate" />
+
         <import type="com.drunkenboys.calendarun.ui.saveschedule.model.DateType" />
 
         <variable
@@ -57,20 +59,20 @@
             app:layout_constraintStart_toStartOf="@+id/tv_checkPoint_name"
             app:layout_constraintTop_toBottomOf="@+id/tv_checkPoint_name" />
 
-        <TextView
+        <com.drunkenboys.calendarun.view.ErrorGuideTextView
             android:id="@+id/tv_checkPoint_startDatePicker"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
+            android:hint="@string/check_point_pickDate"
             android:onClick="@{() -> adapter.onClick.invoke(item, DateType.START)}"
             android:text="@{DateConverterKt.localDateToString(item.startDate)}"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="@+id/tv_checkPoint_startDate"
             app:layout_constraintEnd_toStartOf="@+id/cb_checkPoint_select"
             app:layout_constraintStart_toEndOf="@+id/tv_checkPoint_startDate"
-            app:layout_constraintTop_toTopOf="@+id/tv_checkPoint_startDate"
-            tools:text="2021.03.19" />
+            app:layout_constraintTop_toTopOf="@+id/tv_checkPoint_startDate" />
 
         <TextView
             android:id="@+id/tv_checkPoint_endDate"
@@ -85,19 +87,18 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/tv_checkPoint_startDate" />
 
-        <TextView
+        <com.drunkenboys.calendarun.view.ErrorGuideTextView
             android:id="@+id/tv_checkPoint_endDatePicker"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:hint="@string/check_point_pickDate"
             android:onClick="@{() -> adapter.onClick.invoke(item, DateType.END)}"
             android:text="@{DateConverterKt.localDateToString(item.endDate)}"
             android:textSize="18sp"
             app:layout_constraintBottom_toBottomOf="@+id/tv_checkPoint_endDate"
             app:layout_constraintEnd_toEndOf="@+id/tv_checkPoint_startDatePicker"
             app:layout_constraintStart_toStartOf="@+id/tv_checkPoint_startDatePicker"
-            app:layout_constraintTop_toTopOf="@+id/tv_checkPoint_endDate"
-            tools:text="2021.03.19" />
-
+            app:layout_constraintTop_toTopOf="@+id/tv_checkPoint_endDate" />
 
         <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/cb_checkPoint_select"
@@ -108,25 +109,5 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
-
-        <View
-            android:id="@+id/divider_checkPont_startDatePickerBottom"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginTop="3dp"
-            android:background="@color/black"
-            app:layout_constraintEnd_toEndOf="@id/tv_checkPoint_startDatePicker"
-            app:layout_constraintStart_toStartOf="@id/tv_checkPoint_startDatePicker"
-            app:layout_constraintTop_toBottomOf="@id/tv_checkPoint_startDatePicker" />
-
-        <View
-            android:id="@+id/divider_checkPont_endDatePickerBottom"
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginTop="3dp"
-            android:background="@color/black"
-            app:layout_constraintEnd_toEndOf="@id/tv_checkPoint_endDatePicker"
-            app:layout_constraintStart_toStartOf="@id/tv_checkPoint_endDatePicker"
-            app:layout_constraintTop_toBottomOf="@id/tv_checkPoint_endDatePicker" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="check_point_name">이름</string>
     <string name="check_point_startDate">시작일</string>
     <string name="check_point_endDate">종료일</string>
+    <string name="check_point_pickDate">날짜 선택</string>
 
     <!-- view_check_point_footer-->
     <string name="check_point_footer_save">추가</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="saveCalendar_start_date">시작일</string>
     <string name="saveCalendar_end_date">종료일</string>
     <string name="saveCalendar_save">저장</string>
+    <string name="saveCalendar_defaultCalendar">기본 캘린더</string>
     <string name="menuSaveCalendarToolbar_delete">삭제</string>
 
     <!-- view_check_point -->


### PR DESCRIPTION
## what is this pr
달력 추가할 때 기본 달력을 추가할 지 선택할 수 있는 switch 추가
입력칸 중 빈 칸에 애니메이션 추가
Resolve: #209 #238

## screenshot
기본 캘린더 switch
<img src="https://user-images.githubusercontent.com/50517813/142898382-6fdd1617-5213-47af-9f92-b2de39b7e88c.gif" width=350 />
빈 칸 애니메이션
<img src="https://user-images.githubusercontent.com/50517813/142898165-2c15ed93-25da-44f4-be1f-abf867a6e498.gif" width=350 />

기본 캘린더 양식으로 바뀔 때 expand, collapse 애니메이션 있으면 좋겠음
