### PR TITLE
기본캘린더가 아닐 때 월 표시 추가

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -96,8 +96,7 @@ class YearCalendarViewModel: ViewModel() {
     }
 
     fun fetchNextCalendarSet() {
-        // FIXME: 기본 캘린더와 생성된 캘린더를 구분짓는 로직 하드코딩
-        if (_calendar.value.all { month -> month.name.contains("월") || _calendar.value.isEmpty()}) {
+        if (isDefaultCalendar()) {
             val nextYear = _calendar.value.last().endDate.year + 1
 
             _calendar.value = _calendar.value.plus(createCalendarSets(nextYear))
@@ -105,13 +104,14 @@ class YearCalendarViewModel: ViewModel() {
     }
 
     fun fetchPrevCalendarSet() {
-        // FIXME: 기본 캘린더와 생성된 캘린더를 구분짓는 로직 하드코딩
-        if (_calendar.value.all { month -> month.name.contains("월") || _calendar.value.isEmpty() }) {
+        if (isDefaultCalendar()) {
             val prevYear = _calendar.value.first().startDate.year - 1
 
             _calendar.value = createCalendarSets(prevYear).plus(_calendar.value)
         }
     }
+
+    fun isDefaultCalendar() = _calendar.value.all { month -> month.id < 0}
 
     private fun createCalendarSets(year: Int): List<CalendarSet> {
         val calendarMonth = mutableListOf<CalendarSet>()
@@ -121,7 +121,7 @@ class YearCalendarViewModel: ViewModel() {
         (1..12).forEach { month ->
             startOfMonth = LocalDate.of(year, month, 1)
             endOfMonth = startOfMonth.plusDays(startOfMonth.lengthOfMonth() - 1L)
-            calendarMonth.add(CalendarSet(month, "${month}월", startOfMonth, endOfMonth))
+            calendarMonth.add(CalendarSet(-month, "${month}월", startOfMonth, endOfMonth))
         }
 
         return calendarMonth

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -64,9 +64,9 @@ fun CalendarLazyColumn(
     // RecyclerView와 유사
     LazyColumn(state = listState) {
         items(calendar, key = { slice -> slice.startDate }) { slice ->
-            val firstOfYear = LocalDate.of(slice.endDate.year, 1, 1)
 
-            if (firstOfYear in slice.startDate..slice.endDate)
+            val firstOfYear = LocalDate.of(slice.endDate.year, 1, 1)
+            if (firstOfYear in slice.startDate..slice.endDate) {
                 Text(
                     text = "${firstOfYear.year}년",
                     color = MaterialTheme.colors.primary,
@@ -75,8 +75,9 @@ fun CalendarLazyColumn(
                         .fillMaxWidth(),
                     textAlign = TextAlign.Center
                 )
+            }
 
-            if (!viewModel.isDefaultCalendar())
+            if (!viewModel.isDefaultCalendar()) {
                 Text(
                     text = "${slice.startDate.monthValue}월",
                     color = MaterialTheme.colors.primary,
@@ -85,6 +86,7 @@ fun CalendarLazyColumn(
                         .fillMaxWidth(),
                     textAlign = TextAlign.Center
                 )
+            }
 
             MonthCalendar(
                 month = slice,

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
@@ -75,6 +76,16 @@ fun CalendarLazyColumn(
                     textAlign = TextAlign.Center
                 )
 
+            if (!viewModel.isDefaultCalendar())
+                Text(
+                    text = "${slice.startDate.monthValue}월",
+                    color = MaterialTheme.colors.primary,
+                    modifier = Modifier
+                        .background(color = MaterialTheme.colors.background)
+                        .fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+
             MonthCalendar(
                 month = slice,
                 listState = listState,
@@ -107,6 +118,16 @@ fun PreviewCalendar() {
     viewModel.setDesign(CalendarDesignObject(
         textAlign = Gravity.CENTER
     ))
+
+    // slice test
+    val newSlice = listOf(CalendarSet(
+        id = 0,
+        name = "슬라이스",
+        startDate = LocalDate.now().minusDays(30L),
+        endDate = LocalDate.now().plusDays(30L)
+    ))
+
+    viewModel.setCalendarSetList(newSlice)
 
     CustomTheme(design = viewModel.design.value) {
         CalendarLazyColumn(


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
- Related #222 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 기본 캘린더 calendarSet id는 모두 음수
- 기본 캘린더가 아닐 때 상단에 월표시 추가했는데 두 달이 걸친 월을 표시하는게 찜찜함
## screenshot
<img src="https://user-images.githubusercontent.com/55696672/142962885-7b72b135-6648-49d2-a377-7752c676c0b2.png" width=350 />
