### PR TITLE
월표시 2트

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/weekcalendar/WeekCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/weekcalendar/WeekCalendar.kt
@@ -53,7 +53,7 @@ fun WeekCalendar(
 
                 // 1일
                 else -> Column(modifier = dayModifier(day).layoutId(day.date.toString()), horizontalAlignment = Alignment.CenterHorizontally) {
-                    DayText(day = day, viewModel = viewModel)
+                    DayText(day = day, viewModel = viewModel, false)
                     ScheduleText(today = day.date, weekSchedules, viewModel = viewModel)
                 }
             }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -61,17 +61,20 @@ fun CalendarLazyColumn(
     }
 
     // RecyclerView와 유사
-    LazyColumn(state = listState) {
+    LazyColumn(
+        state = listState,
+        modifier = Modifier.background(color = MaterialTheme.colors.background)
+    ) {
         items(calendar, key = { slice -> slice.startDate }) { slice ->
 
             val firstOfYear = LocalDate.of(slice.endDate.year, 1, 1)
+
+            // 해가 갱신될 때마다 상단에 연표시
             if (firstOfYear in slice.startDate..slice.endDate) {
                 Text(
                     text = "${firstOfYear.year}년",
                     color = MaterialTheme.colors.primary,
-                    modifier = Modifier
-                        .background(color = MaterialTheme.colors.background)
-                        .fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center
                 )
             }
@@ -80,9 +83,7 @@ fun CalendarLazyColumn(
                 Text(
                     text = "${slice.startDate.monthValue}월",
                     color = MaterialTheme.colors.primary,
-                    modifier = Modifier
-                        .background(color = MaterialTheme.colors.background)
-                        .fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center
                 )
             }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -79,15 +79,6 @@ fun CalendarLazyColumn(
                 )
             }
 
-            if (!viewModel.isDefaultCalendar()) {
-                Text(
-                    text = "${slice.startDate.monthValue}월",
-                    color = MaterialTheme.colors.primary,
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = TextAlign.Center
-                )
-            }
-
             MonthCalendar(
                 month = slice,
                 listState = listState,

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -63,7 +64,7 @@ fun CalendarLazyColumn(
     // RecyclerView와 유사
     LazyColumn(
         state = listState,
-        modifier = Modifier.background(color = MaterialTheme.colors.background)
+        modifier = Modifier.background(color = MaterialTheme.colors.background).fillMaxHeight()
     ) {
         items(calendar, key = { slice -> slice.startDate }) { slice ->
 

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.drunkenboys.ckscalendar.data.CalendarDate
@@ -30,12 +31,19 @@ fun DayText(
         else -> MaterialTheme.colors.primary
     }
 
+    val text = if (isFirstOfCalendarSet) {
+        "${day.date.monthValue}."
+    } else {
+        ""
+    } + "${day.date.dayOfMonth}"
+
     Text(
-        text = "${day.date.dayOfMonth}",
+        text = text,
         color = color,
         modifier = Modifier.layoutId(day.date.toString()),
         textAlign = GravityMapper.toTextAlign(viewModel.design.value.textAlign),
-        fontSize = viewModel.design.value.textSize.dp()
+        fontSize = viewModel.design.value.textSize.dp(),
+        fontWeight = if (isFirstOfCalendarSet) FontWeight.Bold else null
     )
 }
 
@@ -44,6 +52,6 @@ fun DayText(
 fun PreviewDayText() {
     val viewModel = YearCalendarViewModel()
     CustomTheme(design = viewModel.design.value) {
-        DayText(day = CalendarDate(date = LocalDate.now(), dayType = DayType.WEEKDAY), viewModel = viewModel)
+        DayText(day = CalendarDate(date = LocalDate.now(), dayType = DayType.WEEKDAY), viewModel = viewModel, true)
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
@@ -20,7 +20,8 @@ import java.time.LocalDate
 @Composable
 fun DayText(
     day: CalendarDate,
-    viewModel: YearCalendarViewModel
+    viewModel: YearCalendarViewModel,
+    isFirstOfCalendarSet: Boolean
 ) {
     val color = when (day.dayType) { // FIXME: month 와 통합
         DayType.HOLIDAY -> Color(viewModel.design.value.holidayTextColor)

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
@@ -32,7 +32,7 @@ fun DayText(
     }
 
     val text = if (isFirstOfCalendarSet) {
-        "${day.date.monthValue}."
+        "${day.date.monthValue}. "
     } else {
         ""
     } + "${day.date.dayOfMonth}"

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
@@ -27,6 +27,9 @@ fun MonthCalendar(
 ) {
     val weeks = calendarSetToCalendarDatesList(month)
     var weekSchedules: Array<Array<CalendarScheduleObject?>> // 1주 스케줄
+    val isFirstOfCalendarSet = { day: CalendarDate ->
+        month.id > 0 && (day.date.dayOfMonth == 1 || day.date == month.startDate)
+    }
 
     weeks.forEach { week ->
         // 1주일
@@ -50,8 +53,17 @@ fun MonthCalendar(
                         modifier = dayColumnModifier(day),
                         horizontalAlignment = GravityMapper.toColumnAlign(viewModel.design.value.textAlign)
                     ) {
-                        DayText(day = day, viewModel = viewModel)
-                        ScheduleText(today = day.date, weekSchedules, viewModel = viewModel)
+                        DayText(
+                            day = day,
+                            viewModel = viewModel,
+                            isFirstOfCalendarSet = isFirstOfCalendarSet(day)
+                        )
+
+                        ScheduleText(
+                            today = day.date,
+                            weekScheduleList = weekSchedules,
+                            viewModel = viewModel
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Related #222 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->

- 기존 월 표시 제거하고 슬라이스 첫날과 매 달 1일에 월을 포함 + bold
- 배경 적용방식 변경
  - 기존: 요일 표시 & 년도 표시에만 적용
  - 현재: 뒷 배경 전체에 적용 
- 슬라이스가 짧으니까 배경이 짤막한데, 앱에서 조절하는게 맞겠죠?

## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/142989789-fa946459-a15f-48dd-875a-45e2d8ceaeef.png" width=350 />


