### PR TITLE
기본 캘린더 삭제할 수 없도록 수정

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarDao.kt
@@ -16,10 +16,13 @@ interface CalendarDao {
     @Query("SELECT * FROM `calendar`")
     suspend fun fetchAllCalendar(): List<Calendar>
 
+    @Query("SELECT * FROM `calendar` WHERE id != 1")
+    suspend fun fetchCustomCalendar(): List<Calendar>
+
     @Query("SELECT * FROM `calendar` WHERE id == :id")
     suspend fun fetchCalendar(id: Long): Calendar
 
     @Delete
     suspend fun deleteCalendar(calendar: Calendar)
-    
+
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSource.kt
@@ -8,6 +8,8 @@ interface CalendarLocalDataSource {
 
     suspend fun fetchAllCalendar(): List<Calendar>
 
+    suspend fun fetchCustomCalendar(): List<Calendar>
+
     suspend fun fetchCalendar(id: Long): Calendar
 
     suspend fun deleteCalendar(calendar: Calendar)

--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSourceImpl.kt
@@ -19,6 +19,10 @@ class CalendarLocalDataSourceImpl @Inject constructor(
         calendarDao.fetchAllCalendar()
     }
 
+    override suspend fun fetchCustomCalendar() = withContext(dispatcher) {
+        calendarDao.fetchCustomCalendar()
+    }
+
     override suspend fun fetchCalendar(id: Long) = withContext(dispatcher) {
         calendarDao.fetchCalendar(id)
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
@@ -25,7 +25,7 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        manageCalendarViewModel.fetchCalendarList()
+        manageCalendarViewModel.fetchCustomCalendarList()
         setupToolbar()
         setupAdapter()
         setupFabClickListener()

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarViewModel.kt
@@ -23,9 +23,9 @@ class ManageCalendarViewModel @Inject constructor(
     private val _deleteCalendarEvent = MutableSharedFlow<Unit>()
     val deleteCalendarEvent: SharedFlow<Unit> = _deleteCalendarEvent
 
-    fun fetchCalendarList() {
+    fun fetchCustomCalendarList() {
         viewModelScope.launch {
-            val calendarList = calendarLocalDataSource.fetchAllCalendar()
+            val calendarList = calendarLocalDataSource.fetchCustomCalendar()
             val newCalendarItemList = mutableListOf<CalendarItem>()
             calendarList.forEach { calendar ->
                 newCalendarItemList.add(
@@ -50,7 +50,7 @@ class ManageCalendarViewModel @Inject constructor(
                         calendarItem.toCalendar()
                     )
                 }
-            fetchCalendarList()
+            fetchCustomCalendarList()
         }
     }
 

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
@@ -18,6 +18,10 @@ class FakeCalendarLocalDataSource : CalendarLocalDataSource {
         return Calendar(0, "test calendar", LocalDate.now(), LocalDate.now())
     }
 
+    override suspend fun fetchCustomCalendar(): List<Calendar> {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun deleteCalendar(calendar: Calendar) {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
## what is this pr
달력 관리 화면에서 기본 캘린더를 숨김으로써 기본 캘린더를 삭제할 수 없도록 수정
fetchCustomCalendar 쿼리 추가
