### PR TITLE
연달력 일정 정렬 & 테두리에 글씨 가리는 버그 해결

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -75,12 +75,13 @@ class YearCalendarViewModel: ViewModel() {
     }
 
     private fun getStartSchedules(today: LocalDate) = schedules.value.filter { schedule ->
-        // TODO: 정렬
         val isStart = schedule.startDate.toLocalDate() == today
         val isSunday = today.dayOfWeek == DayOfWeek.SUNDAY
         val isFirstOfMonth = today.dayOfMonth == 1
         val isDateInScheduleRange = today in schedule.startDate.toLocalDate()..schedule.endDate.toLocalDate()
         isStart || ((isSunday || isFirstOfMonth) && (isDateInScheduleRange))
+    }.sortedBy { schedule ->
+        schedule.startDate
     }
 
     fun isFirstWeek(week: List<CalendarDate>, month: CalendarSet) = week.any { day ->

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -1,6 +1,7 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
 import android.view.Gravity
+import android.view.RoundedCorner
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -10,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
@@ -53,7 +55,7 @@ fun CalendarLazyColumn(
     val dayColumnModifier = { day: CalendarDate ->
         Modifier
             .layoutId(day.date.toString())
-            .border(clickedEdge(day))
+            .border(clickedEdge(day), shape = RoundedCornerShape(6.dp))
             .clickable(onClick = {
                 if (clickedDay != day.date) onDayClickListener?.onDayClick(day.date, 0)
                 else onDaySecondClickListener?.onDayClick(day.date, 0)

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/DayText.kt
@@ -1,5 +1,6 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -7,10 +8,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import com.drunkenboys.ckscalendar.data.CalendarDate
-import com.drunkenboys.ckscalendar.data.CalendarDesignObject
 import com.drunkenboys.ckscalendar.data.DayType
 import com.drunkenboys.ckscalendar.utils.GravityMapper
 import com.drunkenboys.ckscalendar.utils.dp
@@ -40,7 +40,7 @@ fun DayText(
     Text(
         text = text,
         color = color,
-        modifier = Modifier.layoutId(day.date.toString()),
+        modifier = Modifier.layoutId(day.date.toString()).padding(start = 5.dp, end = 5.dp),
         textAlign = GravityMapper.toTextAlign(viewModel.design.value.textAlign),
         fontSize = viewModel.design.value.textSize.dp(),
         fontWeight = if (isFirstOfCalendarSet) FontWeight.Bold else null

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -45,7 +46,7 @@ fun ScheduleText(
             maxLines = 1,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = color(schedule)),
+                .background(color = color(schedule)).padding(4.dp),
             overflow = TextOverflow.Ellipsis,
             fontSize = viewModel.design.value.textSize.dp(),
             color = Color.White


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve #253 

## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 보여지는 일정에 정렬을 추가
- 기존에는 그냥 filter만 씀
- 날짜와 일정에 패딩 4dp 추가

## Screenshot
<img src = "https://user-images.githubusercontent.com/55696672/143216069-fc2207ce-9d73-4910-97f0-00d901c3564c.png" width = 350 />  <img src="https://user-images.githubusercontent.com/55696672/143250600-2c8de0f2-b8e5-473f-91fa-6f602bbe9b8c.png" width= 200 />


