### PR TITLE
일정 검색 페이징

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
@@ -24,10 +24,15 @@ interface ScheduleDao {
     @Delete
     suspend fun deleteSchedule(schedule: Schedule)
 
-    @Query("SELECT * FROM `schedule` WHERE startDate >= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC")
+    @Query("SELECT * FROM `schedule` WHERE startDate >= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC LIMIT $SCHEDULE_PAGING_SIZE")
     suspend fun fetchMatchedScheduleAfter(word: String, time: Long): List<Schedule>
 
-    @Query("SELECT * FROM `schedule` WHERE startDate <= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC")
+    @Query("SELECT * FROM `schedule` WHERE startDate <= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC LIMIT $SCHEDULE_PAGING_SIZE")
     suspend fun fetchMatchedScheduleBefore(word: String, time: Long): List<Schedule>
+
+    companion object {
+
+        const val SCHEDULE_PAGING_SIZE = 30
+    }
 
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
@@ -24,10 +24,10 @@ interface ScheduleDao {
     @Delete
     suspend fun deleteSchedule(schedule: Schedule)
 
-    @Query("SELECT * FROM `schedule` WHERE startDate >= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC LIMIT $SCHEDULE_PAGING_SIZE")
+    @Query("SELECT * FROM `schedule` WHERE startDate > :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC LIMIT $SCHEDULE_PAGING_SIZE")
     suspend fun fetchMatchedScheduleAfter(word: String, time: Long): List<Schedule>
 
-    @Query("SELECT * FROM `schedule` WHERE startDate <= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC LIMIT $SCHEDULE_PAGING_SIZE")
+    @Query("SELECT * FROM (SELECT * FROM `schedule` WHERE startDate < :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate DESC LIMIT $SCHEDULE_PAGING_SIZE) A ORDER BY A.startDate ASC")
     suspend fun fetchMatchedScheduleBefore(word: String, time: Long): List<Schedule>
 
     companion object {

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
@@ -27,4 +27,7 @@ interface ScheduleDao {
     @Query("SELECT * FROM `schedule` WHERE startDate >= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC")
     suspend fun fetchMatchedScheduleAfter(word: String, time: Long): List<Schedule>
 
+    @Query("SELECT * FROM `schedule` WHERE startDate <= :time AND `name` LIKE '%' || :word || '%' ORDER BY startDate ASC")
+    suspend fun fetchMatchedScheduleBefore(word: String, time: Long): List<Schedule>
+
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
@@ -18,4 +18,6 @@ interface ScheduleLocalDataSource {
 
     suspend fun fetchMatchedScheduleAfter(word: String, time: Long): List<Schedule>
 
+    suspend fun fetchMatchedScheduleBefore(word: String, time: Long): List<Schedule>
+
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
@@ -38,4 +38,8 @@ class ScheduleLocalDataSourceImpl @Inject constructor(
     override suspend fun fetchMatchedScheduleAfter(word: String, time: Long) = withContext(dispatcher) {
         scheduleDao.fetchMatchedScheduleAfter(word, time)
     }
+
+    override suspend fun fetchMatchedScheduleBefore(word: String, time: Long) = withContext(dispatcher) {
+        scheduleDao.fetchMatchedScheduleBefore(word, time)
+    }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
@@ -44,10 +44,10 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
 
-                if (!recyclerView.canScrollVertically(-1)) {
+                if (!recyclerView.canScrollVertically(SCROLL_NEGATIVE)) {
                     searchScheduleViewModel.trySearchPrev()
                 }
-                if (!recyclerView.canScrollVertically(1)) {
+                if (!recyclerView.canScrollVertically(SCROLL_POSITIVE)) {
                     searchScheduleViewModel.trySearchNext()
                 }
             }
@@ -66,5 +66,11 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
             val action = SearchScheduleFragmentDirections.toSaveSchedule(schedule.calendarId, schedule.id)
             navController.navigate(action)
         }
+    }
+
+    companion object {
+
+        private const val SCROLL_NEGATIVE = -1
+        private const val SCROLL_POSITIVE = 1
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.ui.setupWithNavController
+import androidx.recyclerview.widget.RecyclerView
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.FragmentSearchScheduleBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
@@ -39,6 +40,18 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
     private fun setupRecyclerView() {
         binding.rvSearchSchedule.adapter = searchScheduleAdapter
         binding.rvSearchSchedule.addItemDecoration(SearchScheduleDivider(requireContext()))
+        binding.rvSearchSchedule.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+
+                if (!recyclerView.canScrollVertically(-1)) {
+                    searchScheduleViewModel.tryFetchPrev()
+                }
+                if (!recyclerView.canScrollVertically(1)) {
+                    searchScheduleViewModel.tryFetchNext()
+                }
+            }
+        })
     }
 
     private suspend fun collectListItem() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
@@ -37,10 +37,10 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
         binding.toolbarSearchSchedule.setupWithNavController(navController)
     }
 
-    private fun setupRecyclerView() {
-        binding.rvSearchSchedule.adapter = searchScheduleAdapter
-        binding.rvSearchSchedule.addItemDecoration(SearchScheduleDivider(requireContext()))
-        binding.rvSearchSchedule.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+    private fun setupRecyclerView() = with(binding.rvSearchSchedule) {
+        adapter = searchScheduleAdapter
+        addItemDecoration(SearchScheduleDivider(requireContext()))
+        addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(recyclerView, dx, dy)
 
@@ -52,6 +52,7 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
                 }
             }
         })
+        itemAnimator = null
     }
 
     private suspend fun collectListItem() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleFragment.kt
@@ -45,10 +45,10 @@ class SearchScheduleFragment : BaseFragment<FragmentSearchScheduleBinding>(R.lay
                 super.onScrolled(recyclerView, dx, dy)
 
                 if (!recyclerView.canScrollVertically(-1)) {
-                    searchScheduleViewModel.tryFetchPrev()
+                    searchScheduleViewModel.trySearchPrev()
                 }
                 if (!recyclerView.canScrollVertically(1)) {
-                    searchScheduleViewModel.tryFetchNext()
+                    searchScheduleViewModel.trySearchNext()
                 }
             }
         })

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -1,5 +1,6 @@
 package com.drunkenboys.calendarun.ui.searchschedule
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
@@ -7,14 +8,12 @@ import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.searchschedule.model.DateItem
 import com.drunkenboys.calendarun.ui.searchschedule.model.DateScheduleItem
 import com.drunkenboys.calendarun.ui.searchschedule.model.ScheduleItem
+import com.drunkenboys.calendarun.util.extensions.throttleFirst
 import com.drunkenboys.calendarun.util.seconds
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -31,16 +30,47 @@ class SearchScheduleViewModel @Inject constructor(
     private val _listItem = MutableStateFlow<List<DateScheduleItem>>(emptyList())
     val listItem: StateFlow<List<DateScheduleItem>> = _listItem
 
+    private val _isSearching = MutableStateFlow(false)
+    val isSearching: StateFlow<Boolean> = _isSearching
+
     private val _scheduleClickEvent = MutableSharedFlow<Schedule>()
     val scheduleClickEvent: SharedFlow<Schedule> = _scheduleClickEvent
 
-    private val _isSearching = MutableStateFlow(false)
-    val isSearching: StateFlow<Boolean> = _isSearching
+    private val searchPrevEvent = MutableSharedFlow<Unit>()
+    private val searchNextEvent = MutableSharedFlow<Unit>()
 
     private var debounceJob: Job = Job()
 
     init {
+        collectSearchEvent()
         searchSchedule()
+    }
+
+    fun tryFetchPrev() {
+        viewModelScope.launch {
+            Log.d("SearchScheduleViewModel", "tryFetchPrev: ")
+            searchPrevEvent.emit(Unit)
+        }
+    }
+
+    fun tryFetchNext() {
+        viewModelScope.launch {
+            Log.d("SearchScheduleViewModel", "tryFetchNext: ")
+            searchNextEvent.emit(Unit)
+        }
+    }
+
+    private fun collectSearchEvent() {
+        viewModelScope.launch {
+            launch {
+                searchPrevEvent.throttleFirst(600)
+                    .collect { Log.d("SearchScheduleViewModel", "collectSearchEvent prev") }
+            }
+            launch {
+                searchNextEvent.throttleFirst(600)
+                    .collect { Log.d("SearchScheduleViewModel", "collectSearchEvent next") }
+            }
+        }
     }
 
     fun searchSchedule(word: String = "") {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -69,11 +69,11 @@ class SearchScheduleViewModel @Inject constructor(
     private fun collectSearchEvent() {
         viewModelScope.launch {
             launch {
-                searchPrevEvent.throttleFirst(600)
+                searchPrevEvent.throttleFirst(PAGING_THROTTLE_DURATION)
                     .collect { prevKey?.let { searchPrev(it) } }
             }
             launch {
-                searchNextEvent.throttleFirst(600)
+                searchNextEvent.throttleFirst(PAGING_THROTTLE_DURATION)
                     .collect { nextKey?.let { searchNext(it) } }
             }
         }
@@ -137,5 +137,6 @@ class SearchScheduleViewModel @Inject constructor(
     companion object {
 
         private const val DEBOUNCE_DURATION = 500L
+        private const val PAGING_THROTTLE_DURATION = 600L
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -1,6 +1,5 @@
 package com.drunkenboys.calendarun.ui.searchschedule
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
@@ -72,7 +71,7 @@ class SearchScheduleViewModel @Inject constructor(
             }
             launch {
                 searchNextEvent.throttleFirst(600)
-                    .collect { Log.d("SearchScheduleViewModel", "collectSearchEvent next") }
+                    .collect { searchSchedule(action = SearchAction.NEXT) }
             }
         }
     }
@@ -95,7 +94,16 @@ class SearchScheduleViewModel @Inject constructor(
                     nextKey = scheduleList.lastOrNull()?.startDate?.toLocalDate()
                 }
             } else if (action == SearchAction.NEXT) {
-                
+                nextKey?.let { key ->
+                    val newList = scheduleDataSource.fetchMatchedScheduleAfter(word, key.seconds)
+                    if (newList.size == 1) {
+                        nextKey = null
+                        return@let
+                    }
+                    scheduleList = scheduleList.takeLast(30) + newList
+                    prevKey = scheduleList.firstOrNull()?.startDate?.toLocalDate()
+                    nextKey = scheduleList.lastOrNull()?.startDate?.toLocalDate()
+                }
             }
 
             _listItem.value = scheduleList.map { schedule -> ScheduleItem(schedule) { emitScheduleClickEvent(schedule) } }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -3,10 +3,12 @@ package com.drunkenboys.calendarun.ui.searchschedule
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
+import com.drunkenboys.calendarun.data.schedule.local.ScheduleDao
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.searchschedule.model.DateItem
 import com.drunkenboys.calendarun.ui.searchschedule.model.DateScheduleItem
 import com.drunkenboys.calendarun.ui.searchschedule.model.ScheduleItem
+import com.drunkenboys.calendarun.util.defaultZoneOffset
 import com.drunkenboys.calendarun.util.extensions.throttleFirst
 import com.drunkenboys.calendarun.util.seconds
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,6 +17,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,11 +43,11 @@ class SearchScheduleViewModel @Inject constructor(
 
     private var debounceJob: Job = Job()
 
-    private var prevKey: LocalDate?
-    private var nextKey: LocalDate?
+    private var prevKey: LocalDateTime?
+    private var nextKey: LocalDateTime?
 
     init {
-        val today = LocalDate.now()
+        val today = LocalDateTime.now()
         prevKey = today
         nextKey = today
         collectSearchEvent()
@@ -67,51 +70,62 @@ class SearchScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             launch {
                 searchPrevEvent.throttleFirst(600)
-                    .collect { searchSchedule(action = SearchAction.PREV) }
+                    .collect { prevKey?.let { searchPrev(it) } }
             }
             launch {
                 searchNextEvent.throttleFirst(600)
-                    .collect { searchSchedule(action = SearchAction.NEXT) }
+                    .collect { nextKey?.let { searchNext(it) } }
             }
         }
     }
 
-    fun searchSchedule(word: String = "", action: SearchAction = SearchAction.NEXT) {
+    fun searchSchedule(word: String = this.word.value) {
         debounceJob.cancel()
         debounceJob = viewModelScope.launch {
             _isSearching.value = true
             delay(DEBOUNCE_DURATION)
 
-            if (action == SearchAction.PREV) {
-                prevKey?.let { key ->
-                    val newList = scheduleDataSource.fetchMatchedScheduleBefore(word, key.seconds)
-                    if (newList.size == 1) {
-                        prevKey = null
-                        return@let
-                    }
-                    scheduleList = newList + scheduleList.take(30)
-                    prevKey = scheduleList.firstOrNull()?.startDate?.toLocalDate()
-                    nextKey = scheduleList.lastOrNull()?.startDate?.toLocalDate()
-                }
-            } else if (action == SearchAction.NEXT) {
-                nextKey?.let { key ->
-                    val newList = scheduleDataSource.fetchMatchedScheduleAfter(word, key.seconds)
-                    if (newList.size == 1) {
-                        nextKey = null
-                        return@let
-                    }
-                    scheduleList = scheduleList.takeLast(30) + newList
-                    prevKey = scheduleList.firstOrNull()?.startDate?.toLocalDate()
-                    nextKey = scheduleList.lastOrNull()?.startDate?.toLocalDate()
-                }
-            }
+            val today = LocalDate.now()
 
-            _listItem.value = scheduleList.map { schedule -> ScheduleItem(schedule) { emitScheduleClickEvent(schedule) } }
-                .groupBy { scheduleItem -> scheduleItem.schedule.startDate.toLocalDate() }
-                .flatMap { (localDate, scheduleList) -> listOf(DateItem(localDate)) + scheduleList }
+            scheduleList = scheduleDataSource.fetchMatchedScheduleAfter(word, today.seconds - 1)
+            prevKey = if (scheduleList.isEmpty()) LocalDateTime.now() else scheduleList.firstOrNull()?.startDate
+            nextKey = scheduleList.lastOrNull()?.startDate
+            updateListItem()
 
             _isSearching.value = false
         }
+    }
+
+    private suspend fun searchPrev(key: LocalDateTime) {
+        val newList = scheduleDataSource.fetchMatchedScheduleBefore(word.value, key.toEpochSecond(defaultZoneOffset))
+        if (newList.isEmpty()) {
+            prevKey = null
+        } else {
+            scheduleList = newList + scheduleList.take(ScheduleDao.SCHEDULE_PAGING_SIZE)
+            prevKey = scheduleList.firstOrNull()?.startDate
+            nextKey = scheduleList.lastOrNull()?.startDate
+
+            updateListItem()
+        }
+    }
+
+    private suspend fun searchNext(key: LocalDateTime) {
+        val newList = scheduleDataSource.fetchMatchedScheduleAfter(word.value, key.toEpochSecond(defaultZoneOffset))
+        if (newList.isEmpty()) {
+            nextKey = null
+        } else {
+            scheduleList = scheduleList.takeLast(ScheduleDao.SCHEDULE_PAGING_SIZE) + newList
+            prevKey = scheduleList.firstOrNull()?.startDate
+            nextKey = scheduleList.lastOrNull()?.startDate
+
+            updateListItem()
+        }
+    }
+
+    private fun updateListItem() {
+        _listItem.value = scheduleList.map { schedule -> ScheduleItem(schedule) { emitScheduleClickEvent(schedule) } }
+            .groupBy { scheduleItem -> scheduleItem.schedule.startDate.toLocalDate() }
+            .flatMap { (localDate, scheduleList) -> listOf(DateItem(localDate)) + scheduleList }
     }
 
     private fun emitScheduleClickEvent(schedule: Schedule) {
@@ -124,8 +138,4 @@ class SearchScheduleViewModel @Inject constructor(
 
         private const val DEBOUNCE_DURATION = 500L
     }
-}
-
-enum class SearchAction {
-    PREV, NEXT
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/searchschedule/SearchScheduleViewModel.kt
@@ -54,13 +54,13 @@ class SearchScheduleViewModel @Inject constructor(
         searchSchedule()
     }
 
-    fun tryFetchPrev() {
+    fun trySearchPrev() {
         viewModelScope.launch {
             searchPrevEvent.emit(Unit)
         }
     }
 
-    fun tryFetchNext() {
+    fun trySearchNext() {
         viewModelScope.launch {
             searchNextEvent.emit(Unit)
         }

--- a/app/src/main/res/layout/fragment_search_schedule.xml
+++ b/app/src/main/res/layout/fragment_search_schedule.xml
@@ -8,6 +8,8 @@
 
         <import type="android.view.View" />
 
+        <import type="com.drunkenboys.calendarun.ui.searchschedule.SearchAction" />
+
         <variable
             name="viewModel"
             type="com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleViewModel" />
@@ -36,7 +38,7 @@
                     android:id="@+id/et_searchSchedule_toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:afterTextChanged="@{(text) -> viewModel.searchSchedule(text.toString())}"
+                    android:afterTextChanged="@{(text) -> viewModel.searchSchedule(text.toString(), SearchAction.NEXT)}"
                     android:backgroundTint="@color/white_alpha_50"
                     android:hint="@string/searchSchedule_toolbarHint"
                     android:importantForAutofill="no"

--- a/app/src/main/res/layout/fragment_search_schedule.xml
+++ b/app/src/main/res/layout/fragment_search_schedule.xml
@@ -8,8 +8,6 @@
 
         <import type="android.view.View" />
 
-        <import type="com.drunkenboys.calendarun.ui.searchschedule.SearchAction" />
-
         <variable
             name="viewModel"
             type="com.drunkenboys.calendarun.ui.searchschedule.SearchScheduleViewModel" />
@@ -38,7 +36,7 @@
                     android:id="@+id/et_searchSchedule_toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:afterTextChanged="@{(text) -> viewModel.searchSchedule(text.toString(), SearchAction.NEXT)}"
+                    android:afterTextChanged="@{(text) -> viewModel.searchSchedule(text.toString())}"
                     android:backgroundTint="@color/white_alpha_50"
                     android:hint="@string/searchSchedule_toolbarHint"
                     android:importantForAutofill="no"

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
@@ -35,6 +35,10 @@ class FakeScheduleLocalDataSource : ScheduleLocalDataSource {
     }
 
     override suspend fun fetchMatchedScheduleAfter(word: String, time: Long): List<Schedule> {
-        return database.filter { it.startDate.toEpochSecond(defaultZoneOffset) >= time && word in it.name }
+        return database.filter { it.startDate.toEpochSecond(defaultZoneOffset) > time && word in it.name }
+    }
+
+    override suspend fun fetchMatchedScheduleBefore(word: String, time: Long): List<Schedule> {
+        return database.filter { it.startDate.toEpochSecond(defaultZoneOffset) < time && word in it.name }
     }
 }


### PR DESCRIPTION
## what is this pr
조잡한 듯 보이는 검색 페이징을 구현하였음.
- 리사이클러 뷰 스크롤 리스너로 스크롤의 시작과 끝에서 데이터를 추가로 로드.
- 지금은 시작과 끝에서만 데이터를 로드하기 때문에 스크롤을 빠르게 하면 대기 시간이 필요한데 개선 포인트가 될 수 있을듯.
- 페이징 단위는 30을 기본 값으로 하여 추가 검색 시 스크롤 유지를 위해 이전의 데이터와 검색한 데이터를 합친 후 어댑터에 전달.
- 따라서 일정의 수는 최대 60개를 넘지 않음.
- 시간이 남으면 Paging3로 변경될지도?

Resolve: #201 

## Changes
- 일정 검색 방식 변경
- 페이징을 위한 쿼리 추가

## screenshot
<img src="https://user-images.githubusercontent.com/52354794/143220853-eb5c311e-bdde-40f2-86a7-8a63085b79dc.gif" width=350 />


