### PR TITLE
MainCalendarFragment, MainCalendarViewModel 리팩터링

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/MainActivity.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/MainActivity.kt
@@ -11,8 +11,10 @@ import android.widget.EditText
 import androidx.core.content.getSystemService
 import androidx.core.view.GestureDetectorCompat
 import androidx.navigation.NavDeepLinkBuilder
+import androidx.navigation.fragment.NavHostFragment
 import com.drunkenboys.calendarun.databinding.ActivityMainBinding
 import com.drunkenboys.calendarun.ui.base.BaseViewActivity
+import com.drunkenboys.calendarun.ui.maincalendar.MainCalendarFragmentArgs
 import com.drunkenboys.calendarun.ui.maincalendar.MainCalendarFragmentDirections
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -23,12 +25,25 @@ class MainActivity : BaseViewActivity<ActivityMainBinding>(ActivityMainBinding::
 
     private var prevFocus: View? = null
 
+    private val calendarId by lazy {
+        val pref = getSharedPreferences(CALENDAR_ID_PREF, Context.MODE_PRIVATE)
+        pref.getLong(KEY_CALENDAR_ID, 1)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mDetector = GestureDetectorCompat(this, SingleTapListener())
+
+        setupNavHostFragment()
     }
 
-    // TODO: 2021-11-09 알림 클릭 시 Fragment 내비게이션 구현
+    private fun setupNavHostFragment() {
+        val navHost = NavHostFragment.create(R.navigation.nav_main, MainCalendarFragmentArgs(calendarId).toBundle())
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.layout_main_container, navHost)
+            .setPrimaryNavigationFragment(navHost)
+            .commit()
+    }
 
     // 터치 영역에 따라 키보드를 숨기기 위해 구현
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
@@ -68,6 +83,8 @@ class MainActivity : BaseViewActivity<ActivityMainBinding>(ActivityMainBinding::
     }
 
     companion object {
+
+        const val CALENDAR_ID_PREF = "calendar_id_pref"
 
         fun createNavigationPendingIntent(context: Context, calendarId: Long, startDate: String) = NavDeepLinkBuilder(context)
             .setGraph(R.navigation.nav_main)

--- a/app/src/main/java/com/drunkenboys/calendarun/MainActivity.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/MainActivity.kt
@@ -34,7 +34,9 @@ class MainActivity : BaseViewActivity<ActivityMainBinding>(ActivityMainBinding::
         super.onCreate(savedInstanceState)
         mDetector = GestureDetectorCompat(this, SingleTapListener())
 
-        setupNavHostFragment()
+        if (savedInstanceState == null) {
+            setupNavHostFragment()
+        }
     }
 
     private fun setupNavHostFragment() {

--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarDao.kt
@@ -2,6 +2,7 @@ package com.drunkenboys.calendarun.data.calendar.local
 
 import androidx.room.*
 import com.drunkenboys.calendarun.data.calendar.entity.Calendar
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CalendarDao {
@@ -10,7 +11,7 @@ interface CalendarDao {
     suspend fun insertCalendar(calendar: Calendar): Long
 
     @Query("SELECT * FROM `calendar`")
-    suspend fun fetchAllCalendar(): List<Calendar>
+    fun fetchAllCalendar(): Flow<List<Calendar>>
 
     @Query("SELECT * FROM `calendar` WHERE id != 1")
     suspend fun fetchCustomCalendar(): List<Calendar>

--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSource.kt
@@ -1,12 +1,13 @@
 package com.drunkenboys.calendarun.data.calendar.local
 
 import com.drunkenboys.calendarun.data.calendar.entity.Calendar
+import kotlinx.coroutines.flow.Flow
 
 interface CalendarLocalDataSource {
 
     suspend fun insertCalendar(calendar: Calendar): Long
 
-    suspend fun fetchAllCalendar(): List<Calendar>
+    fun fetchAllCalendar(): Flow<List<Calendar>>
 
     suspend fun fetchCustomCalendar(): List<Calendar>
 

--- a/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/calendar/local/CalendarLocalDataSourceImpl.kt
@@ -15,9 +15,7 @@ class CalendarLocalDataSourceImpl @Inject constructor(
         calendarDao.insertCalendar(calendar)
     }
 
-    override suspend fun fetchAllCalendar() = withContext(dispatcher) {
-        calendarDao.fetchAllCalendar()
-    }
+    override fun fetchAllCalendar() = calendarDao.fetchAllCalendar()
 
     override suspend fun fetchCustomCalendar() = withContext(dispatcher) {
         calendarDao.fetchCustomCalendar()

--- a/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import com.drunkenboys.calendarun.data.checkpoint.entity.CheckPoint
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CheckPointDao {
@@ -19,7 +20,7 @@ interface CheckPointDao {
     suspend fun fetchCheckPoint(id: Long): CheckPoint
 
     @Query("SELECT * FROM `checkpoint` WHERE calendarId == :calendarId")
-    suspend fun fetchCalendarCheckPoints(calendarId: Long): List<CheckPoint>
+    fun fetchCalendarCheckPoints(calendarId: Long): Flow<List<CheckPoint>>
 
     @Update
     suspend fun updateCheckPoint(checkPoint: CheckPoint)

--- a/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointLocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.drunkenboys.calendarun.data.checkpoint.local
 
 import com.drunkenboys.calendarun.data.checkpoint.entity.CheckPoint
+import kotlinx.coroutines.flow.Flow
 
 interface CheckPointLocalDataSource {
 
@@ -10,7 +11,7 @@ interface CheckPointLocalDataSource {
 
     suspend fun fetchCheckPoint(id: Long): CheckPoint
 
-    suspend fun fetchCalendarCheckPoints(calendarId: Long): List<CheckPoint>
+    fun fetchCalendarCheckPoints(calendarId: Long): Flow<List<CheckPoint>>
 
     suspend fun updateCheckPoint(checkPoint: CheckPoint)
 

--- a/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/checkpoint/local/CheckPointLocalDataSourceImpl.kt
@@ -23,10 +23,7 @@ class CheckPointLocalDataSourceImpl @Inject constructor(
         checkPointDao.fetchCheckPoint(id)
     }
 
-    override suspend fun fetchCalendarCheckPoints(calendarId: Long) = withContext(dispatcher) {
-        checkPointDao.fetchCalendarCheckPoints(calendarId)
-    }
-
+    override fun fetchCalendarCheckPoints(calendarId: Long) = checkPointDao.fetchCalendarCheckPoints(calendarId)
 
     override suspend fun updateCheckPoint(checkPoint: CheckPoint) {
         checkPointDao.updateCheckPoint(checkPoint)

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleDao.kt
@@ -2,6 +2,7 @@ package com.drunkenboys.calendarun.data.schedule.local
 
 import androidx.room.*
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ScheduleDao {
@@ -16,7 +17,7 @@ interface ScheduleDao {
     suspend fun fetchSchedule(id: Long): Schedule
 
     @Query("SELECT * FROM `schedule` WHERE calendarId == :calendarId")
-    suspend fun fetchCalendarSchedules(calendarId: Long): List<Schedule>
+    fun fetchCalendarSchedules(calendarId: Long): Flow<List<Schedule>>
 
     @Update
     suspend fun updateSchedule(schedule: Schedule)

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSource.kt
@@ -1,6 +1,7 @@
 package com.drunkenboys.calendarun.data.schedule.local
 
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
+import kotlinx.coroutines.flow.Flow
 
 interface ScheduleLocalDataSource {
 
@@ -10,7 +11,7 @@ interface ScheduleLocalDataSource {
 
     suspend fun fetchSchedule(id: Long): Schedule
 
-    suspend fun fetchCalendarSchedules(calendarId: Long): List<Schedule>
+    fun fetchCalendarSchedules(calendarId: Long): Flow<List<Schedule>>
 
     suspend fun updateSchedule(schedule: Schedule)
 

--- a/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/data/schedule/local/ScheduleLocalDataSourceImpl.kt
@@ -19,9 +19,7 @@ class ScheduleLocalDataSourceImpl @Inject constructor(
         scheduleDao.fetchAllSchedule()
     }
 
-    override suspend fun fetchCalendarSchedules(calendarId: Long) = withContext(dispatcher) {
-        scheduleDao.fetchCalendarSchedules(calendarId)
-    }
+    override fun fetchCalendarSchedules(calendarId: Long) = scheduleDao.fetchCalendarSchedules(calendarId)
 
     override suspend fun fetchSchedule(id: Long) = withContext(dispatcher) {
         scheduleDao.fetchSchedule(id)

--- a/app/src/main/java/com/drunkenboys/calendarun/receiver/BootReceiver.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/receiver/BootReceiver.kt
@@ -11,6 +11,7 @@ import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import javax.inject.Inject
@@ -39,8 +40,8 @@ class BootReceiver : BroadcastReceiver() {
 
     private fun setNotifications(context: Context) {
         coroutineScope.launch {
-            val calendarMap = calendarDataSource.fetchAllCalendar()
-                .associate { it.id to it.name }
+            val calendarMap = calendarDataSource.fetchAllCalendar().firstOrNull()
+                ?.associate { it.id to it.name } ?: return@launch
 
             scheduleDataSource.fetchAllSchedule()
                 .forEach { schedule ->

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/dayschedule/DayScheduleViewModel.kt
@@ -8,10 +8,7 @@ import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.data.schedule.local.ScheduleLocalDataSource
 import com.drunkenboys.calendarun.ui.searchschedule.model.ScheduleItem
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -38,13 +35,13 @@ class DayScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             _dateString.emit(localDate.format(DateTimeFormatter.ofPattern("M월 d일")))
 
-            scheduleDataSource.fetchCalendarSchedules(calendarId)
-                .filter { localDate in it.startDate.toLocalDate()..it.endDate.toLocalDate() }
-                .map { schedule ->
+            scheduleDataSource.fetchCalendarSchedules(calendarId).firstOrNull()
+                ?.filter { localDate in it.startDate.toLocalDate()..it.endDate.toLocalDate() }
+                ?.map { schedule ->
                     ScheduleItem(schedule) { emitScheduleClickEvent(schedule) }
                 }
-                .sortedBy { dateScheduleItem -> dateScheduleItem.schedule.startDate }
-                .let { _listItem.emit(it) }
+                ?.sortedBy { dateScheduleItem -> dateScheduleItem.schedule.startDate }
+                ?.let { _listItem.emit(it) }
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -195,9 +195,10 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     }
 
     private suspend fun collectCalendarDesignObject() {
-        mainCalendarViewModel.fetchCalendarDesignObject().collect {
-            binding.calendarMonth.setDesign(it)
-            binding.calendarYear.setTheme(it)
+        mainCalendarViewModel.calendarDesignObject.collect { designObj ->
+            designObj ?: return@collect
+            binding.calendarMonth.setDesign(designObj)
+            binding.calendarYear.setTheme(designObj)
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -16,10 +16,12 @@ import com.drunkenboys.calendarun.ui.base.BaseFragment
 import com.drunkenboys.calendarun.util.extensions.*
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
+@ExperimentalCoroutinesApi
 class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.fragment_main_calendar) {
 
     private val mainCalendarViewModel by viewModels<MainCalendarViewModel>()
@@ -59,7 +61,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
                 .setCheckable(true)
                 .setOnMenuItemClickListener {
 //                    mainCalendarViewModel.setSelectedCalendarIndex(index)
-                    mainCalendarViewModel.setCalendar(calendar)
+//                    mainCalendarViewModel.setCalendar(calendar)
                     mainCalendarViewModel.setCalendarId(calendar.id)
                     binding.layoutDrawer.close()
                     LoadingDialog().show(childFragmentManager, this::class.simpleName)

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.core.view.GravityCompat
 import androidx.core.view.get
 import androidx.core.view.isEmpty
-import androidx.core.view.isVisible
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.viewModels
 import androidx.navigation.ui.setupWithNavController
@@ -25,12 +24,10 @@ import kotlinx.coroutines.launch
 class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.fragment_main_calendar) {
 
     private val mainCalendarViewModel by viewModels<MainCalendarViewModel>()
-    private var isMonthCalendar = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        setupCalendarView()
         setupDataBinding()
         setupToolbar()
         setupMonthCalendar()
@@ -44,12 +41,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
             launch { collectCalendarDesignObject() }
             launch { collectLicenseClickEvent() }
         }
-    }
-
-    private fun setupCalendarView() {
-        // TODO: CalendarView 내부로 전환
-        binding.calendarMonth.isVisible = isMonthCalendar
-        binding.calendarYear.isVisible = !isMonthCalendar
     }
 
     private fun setupDataBinding() {
@@ -175,10 +166,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     private fun setupOnMenuItemClickListener() {
         binding.toolbarMainCalendar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
-                R.id.menu_main_calendar_calendar -> {
-                    isMonthCalendar = !isMonthCalendar
-                    setupCalendarView()
-                }
+                R.id.menu_main_calendar_calendar -> mainCalendarViewModel.toggleCalendar()
                 R.id.menu_main_calendar_search -> navigateToSearchSchedule()
                 else -> return@setOnMenuItemClickListener false
             }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.fragment.app.viewModels
+import androidx.navigation.navGraphViewModels
 import androidx.navigation.ui.setupWithNavController
 import com.drunkenboys.calendarun.KEY_CALENDAR_ID
 import com.drunkenboys.calendarun.MainActivity
@@ -24,7 +24,8 @@ import kotlinx.coroutines.launch
 @ExperimentalCoroutinesApi
 class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.fragment_main_calendar) {
 
-    private val mainCalendarViewModel by viewModels<MainCalendarViewModel>()
+    private val mainCalendarViewModel
+            by navGraphViewModels<MainCalendarViewModel>(R.id.mainCalendarFragment) { defaultViewModelProviderFactory }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -45,6 +45,9 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
     private fun setupDataBinding() {
         binding.mainCalendarViewModel = mainCalendarViewModel
+        val drawerHeaderBinding = DrawerHeaderBinding.bind(binding.navView.getHeaderView(FIRST_HEADER))
+        drawerHeaderBinding.viewModel = mainCalendarViewModel
+        drawerHeaderBinding.lifecycleOwner = viewLifecycleOwner
     }
 
     private fun setupNavigationView(calendarList: List<Calendar>) {
@@ -127,20 +130,15 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     private fun setupToolbar() {
         binding.toolbarMainCalendar.setupWithNavController(navController, binding.layoutDrawer)
         setupOnMenuItemClickListener()
-        setupAddDrawerListener()
+//        setupAddDrawerListener()
     }
 
     private fun setupAddDrawerListener() = with(binding) {
-        val drawerHeaderBinding = DrawerHeaderBinding.bind(navView.getHeaderView(FIRST_HEADER))
         layoutDrawer.addDrawerListener(object : DrawerLayout.DrawerListener {
             override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
                 val index = this@MainCalendarFragment.mainCalendarViewModel.selectCalendarIndex.value
                 if (binding.navView.menu.isEmpty()) return
                 binding.navView.menu[index].isChecked = true
-                drawerHeaderBinding.tvDrawerHeaderTitle.text = binding.navView.menu[index].title
-                drawerHeaderBinding.tvDrawerHeaderSetting.setOnClickListener {
-                    this@MainCalendarFragment.mainCalendarViewModel.emitLicenseClickEvent()
-                }
             }
 
             override fun onDrawerOpened(drawerView: View) {}

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -3,7 +3,6 @@ package com.drunkenboys.calendarun.ui.maincalendar
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.core.view.GravityCompat
 import androidx.core.view.get
 import androidx.core.view.isEmpty
 import androidx.drawerlayout.widget.DrawerLayout
@@ -47,69 +46,55 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     }
 
     private fun setupNavigationView(calendarList: List<Calendar>) {
+        addCalendarMenu(calendarList)
+        inflateDrawerMenu()
+    }
+
+    private fun addCalendarMenu(calendarList: List<Calendar>) {
         val menu = binding.navView.menu
         menu.clear()
-
         calendarList.forEachIndexed { index, calendar ->
             menu.add(calendar.name)
                 .setIcon(R.drawable.ic_favorite_24)
                 .setCheckable(true)
                 .setOnMenuItemClickListener {
 //                    mainCalendarViewModel.setSelectedCalendarIndex(index)
-//                    mainCalendarViewModel.setCalendar(calendar)
+                    mainCalendarViewModel.setCalendar(calendar)
                     mainCalendarViewModel.setCalendarId(calendar.id)
-                    binding.layoutDrawer.closeDrawer(GravityCompat.START)
+                    binding.layoutDrawer.close()
                     LoadingDialog().show(childFragmentManager, this::class.simpleName)
                     true
                 }
         }
+    }
 
-        menu.add(getString(R.string.calendar_add))
-            .setIcon(R.drawable.ic_add)
-            .setOnMenuItemClickListener {
-                navigateToSaveCalendar()
-                true
+    private fun inflateDrawerMenu() {
+        binding.navView.inflateMenu(R.menu.menu_main_calendar_nav_drawer)
+        binding.navView.setNavigationItemSelectedListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.menu_mainCalendar_addCalendar -> navigateToSaveCalendar()
+                R.id.menu_mainCalendar_calendarManage -> navigateToManageCalendar()
+                R.id.menu_mainCalendar_themeSetting -> navigateToThemeFragment()
+                R.id.menu_mainCalendar_license -> mainCalendarViewModel.emitLicenseClickEvent()
             }
-
-        val manageMenu = menu.addSubMenu(getString(R.string.drawer_calendar_manage))
-        manageMenu.add(getString(R.string.drawer_calendar_manage))
-            .setIcon(R.drawable.ic_calendar_today)
-            .setOnMenuItemClickListener {
-                navigateToManageCalendar()
-                true
-            }
-
-        manageMenu.add(getString(R.string.drawer_theme_setting))
-            .setIcon(R.drawable.ic_palette)
-            .setOnMenuItemClickListener {
-                navigateToThemeFragment()
-                true
-            }
-
-        manageMenu.add(getString(R.string.drawer_license))
-            .setIcon(R.drawable.ic_license)
-            .setOnMenuItemClickListener {
-                mainCalendarViewModel.emitLicenseClickEvent()
-                true
-            }
+            binding.layoutDrawer.close()
+            true
+        }
     }
 
     private fun navigateToSaveCalendar() {
         val action = MainCalendarFragmentDirections.toSaveCalendar()
         navController.navigate(action)
-        binding.layoutDrawer.closeDrawer(GravityCompat.START)
     }
 
     private fun navigateToManageCalendar() {
         val action = MainCalendarFragmentDirections.toManageCalendar()
         navController.navigate(action)
-        binding.layoutDrawer.closeDrawer(GravityCompat.START)
     }
 
     private fun navigateToThemeFragment() {
         val action = MainCalendarFragmentDirections.toThemeFragment()
         navController.navigate(action)
-        binding.layoutDrawer.closeDrawer(GravityCompat.START)
     }
 
     private suspend fun collectScheduleList() {
@@ -206,7 +191,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         mainCalendarViewModel.licenseClickEvent
             .throttleFirst(DEFAULT_TOUCH_THROTTLE_PERIOD)
             .collect {
-                binding.layoutDrawer.closeDrawer(GravityCompat.START)
                 startActivity(Intent(this@MainCalendarFragment.context, OssLicensesMenuActivity::class.java))
             }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -34,9 +34,9 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
         launchAndRepeatWithViewLifecycle {
             launch { collectCalendarId() }
-            launch { collectScheduleList() }
-            launch { collectCalendarSet() }
             launch { collectCalendarList() }
+            launch { collectCalendarSet() }
+            launch { collectScheduleList() }
             launch { collectFabClickEvent() }
             launch { collectDaySecondClickListener() }
             launch { collectCalendarDesignObject() }
@@ -49,6 +49,42 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         val drawerHeaderBinding = DrawerHeaderBinding.bind(binding.navView.getHeaderView(FIRST_HEADER))
         drawerHeaderBinding.viewModel = mainCalendarViewModel
         drawerHeaderBinding.lifecycleOwner = viewLifecycleOwner
+    }
+
+    private fun setupToolbar() {
+        binding.toolbarMainCalendar.setupWithNavController(navController, binding.layoutDrawer)
+        setupOnMenuItemClickListener()
+    }
+
+    private fun setupOnMenuItemClickListener() {
+        binding.toolbarMainCalendar.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                R.id.menu_main_calendar_calendar -> mainCalendarViewModel.toggleCalendar()
+                R.id.menu_main_calendar_search -> navigateToSearchSchedule()
+                else -> return@setOnMenuItemClickListener false
+            }
+            true
+        }
+    }
+
+    private fun navigateToSearchSchedule() {
+        val action = MainCalendarFragmentDirections.toSearchSchedule()
+        navController.navigate(action)
+    }
+
+    private suspend fun collectCalendarId() {
+        mainCalendarViewModel.calendarId.collect { calendarId ->
+            val pref = requireContext().getSharedPreferences(MainActivity.CALENDAR_ID_PREF, Context.MODE_PRIVATE)
+            pref.edit()
+                .putLong(KEY_CALENDAR_ID, calendarId)
+                .apply()
+        }
+    }
+
+    private suspend fun collectCalendarList() {
+        mainCalendarViewModel.calendarList.collect { calendarList ->
+            setupNavigationView(calendarList)
+        }
     }
 
     private fun setupNavigationView(calendarList: List<Calendar>) {
@@ -103,22 +139,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         navController.navigate(action)
     }
 
-    private suspend fun collectCalendarId() {
-        mainCalendarViewModel.calendarId.collect { calendarId ->
-            val pref = requireContext().getSharedPreferences(MainActivity.CALENDAR_ID_PREF, Context.MODE_PRIVATE)
-            pref.edit()
-                .putLong(KEY_CALENDAR_ID, calendarId)
-                .apply()
-        }
-    }
-
-    private suspend fun collectScheduleList() {
-        mainCalendarViewModel.scheduleList.collect { scheduleList ->
-            binding.calendarMonth.setSchedules(scheduleList)
-            binding.calendarYear.setSchedules(scheduleList)
-        }
-    }
-
     private suspend fun collectCalendarSet() {
         mainCalendarViewModel.calendarSetList.collect { calendarSetList ->
             if (calendarSetList.isEmpty()) {
@@ -131,31 +151,11 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         }
     }
 
-    private suspend fun collectCalendarList() {
-        mainCalendarViewModel.calendarList.collect { calendarList ->
-            setupNavigationView(calendarList)
+    private suspend fun collectScheduleList() {
+        mainCalendarViewModel.scheduleList.collect { scheduleList ->
+            binding.calendarMonth.setSchedules(scheduleList)
+            binding.calendarYear.setSchedules(scheduleList)
         }
-    }
-
-    private fun setupToolbar() {
-        binding.toolbarMainCalendar.setupWithNavController(navController, binding.layoutDrawer)
-        setupOnMenuItemClickListener()
-    }
-
-    private fun setupOnMenuItemClickListener() {
-        binding.toolbarMainCalendar.setOnMenuItemClickListener { item ->
-            when (item.itemId) {
-                R.id.menu_main_calendar_calendar -> mainCalendarViewModel.toggleCalendar()
-                R.id.menu_main_calendar_search -> navigateToSearchSchedule()
-                else -> return@setOnMenuItemClickListener false
-            }
-            true
-        }
-    }
-
-    private fun navigateToSearchSchedule() {
-        val action = MainCalendarFragmentDirections.toSearchSchedule()
-        navController.navigate(action)
     }
 
     private suspend fun collectFabClickEvent() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -30,7 +30,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
         setupDataBinding()
         setupToolbar()
-        setupMonthCalendar()
 
         launchAndRepeatWithViewLifecycle {
             launch { collectScheduleList() }
@@ -177,17 +176,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
     private fun navigateToSearchSchedule() {
         val action = MainCalendarFragmentDirections.toSearchSchedule()
         navController.navigate(action)
-    }
-
-    private fun setupMonthCalendar() {
-        // TODO: 2021-11-16 이벤트를 발행하는 부분을 xml로 이동시킬 수 있으면 좋을듯
-        binding.calendarMonth.setOnDaySecondClickListener { date, _ ->
-            mainCalendarViewModel.emitDaySecondClickEvent(date)
-        }
-
-        binding.calendarYear.setOnDaySecondClickListener { date, _ ->
-            mainCalendarViewModel.emitDaySecondClickEvent(date)
-        }
     }
 
     private suspend fun collectFabClickEvent() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -44,7 +44,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
             launch { collectCalendarDesignObject() }
             launch { collectLicenseClickEvent() }
         }
-        mainCalendarViewModel.fetchCalendarList()
     }
 
     private fun setupCalendarView() {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -44,7 +44,6 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
             launch { collectCalendarDesignObject() }
             launch { collectLicenseClickEvent() }
         }
-        mainCalendarViewModel.fetchCalendar()
         mainCalendarViewModel.fetchCalendarList()
     }
 
@@ -67,8 +66,9 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
                 .setIcon(R.drawable.ic_favorite_24)
                 .setCheckable(true)
                 .setOnMenuItemClickListener {
-                    mainCalendarViewModel.setSelectedCalendarIndex(index)
-                    mainCalendarViewModel.setCalendar(calendar)
+//                    mainCalendarViewModel.setSelectedCalendarIndex(index)
+//                    mainCalendarViewModel.setCalendar(calendar)
+                    mainCalendarViewModel.setCalendarId(calendar.id)
                     binding.layoutDrawer.closeDrawer(GravityCompat.START)
                     LoadingDialog().show(childFragmentManager, this::class.simpleName)
                     true
@@ -214,8 +214,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
         mainCalendarViewModel.daySecondClickEvent
             .throttleFirst(DEFAULT_TOUCH_THROTTLE_PERIOD)
             .collect { date ->
-                val calendarId = mainCalendarViewModel.calendar.value?.id ?: throw IllegalStateException("calendarId is null")
-                val action = MainCalendarFragmentDirections.toDayScheduleDialog(calendarId, date.toString())
+                val action = MainCalendarFragmentDirections.toDayScheduleDialog(mainCalendarViewModel.calendarId.value, date.toString())
                 navController.navigateSafe(action)
             }
     }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarFragment.kt
@@ -1,10 +1,13 @@
 package com.drunkenboys.calendarun.ui.maincalendar
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.ui.setupWithNavController
+import com.drunkenboys.calendarun.KEY_CALENDAR_ID
+import com.drunkenboys.calendarun.MainActivity
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.data.calendar.entity.Calendar
 import com.drunkenboys.calendarun.databinding.DrawerHeaderBinding
@@ -68,7 +71,7 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
                 }
         }
         val currentCalendarId = mainCalendarViewModel.calendarId.value
-        binding.navView.menu.findItem(currentCalendarId.toInt()).isChecked = true
+        menu.findItem(currentCalendarId.toInt())?.isChecked = true
     }
 
     private fun inflateDrawerMenu() {
@@ -102,7 +105,10 @@ class MainCalendarFragment : BaseFragment<FragmentMainCalendarBinding>(R.layout.
 
     private suspend fun collectCalendarId() {
         mainCalendarViewModel.calendarId.collect { calendarId ->
-            binding.navView.setCheckedItem(calendarId.toInt())
+            val pref = requireContext().getSharedPreferences(MainActivity.CALENDAR_ID_PREF, Context.MODE_PRIVATE)
+            pref.edit()
+                .putLong(KEY_CALENDAR_ID, calendarId)
+                .apply()
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -38,8 +38,8 @@ class MainCalendarViewModel @Inject constructor(
         calendarLocalDataSource.fetchCalendar(it).name
     }.stateIn(viewModelScope, SharingStarted.Eagerly, "")
 
-    private val _calendarList = MutableStateFlow<List<Calendar>>(emptyList())
-    val calendarList: StateFlow<List<Calendar>> = _calendarList
+    val calendarList = calendarLocalDataSource.fetchAllCalendar()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _scheduleList = MutableStateFlow<List<CalendarScheduleObject>>(emptyList())
     val scheduleList: StateFlow<List<CalendarScheduleObject>> = _scheduleList
@@ -61,7 +61,6 @@ class MainCalendarViewModel @Inject constructor(
 
     init {
         fetchCalendar()
-        fetchCalendarList()
     }
 
     fun fetchCalendar() {
@@ -75,12 +74,6 @@ class MainCalendarViewModel @Inject constructor(
         viewModelScope.launch {
             createCalendarSetList(calendar.id, fetchCheckPointList(calendar.id))
             fetchScheduleList(calendar.id)
-        }
-    }
-
-    fun fetchCalendarList() {
-        viewModelScope.launch {
-            _calendarList.emit(calendarLocalDataSource.fetchAllCalendar())
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -22,7 +22,6 @@ import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
-@ExperimentalCoroutinesApi
 class MainCalendarViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val calendarLocalDataSource: CalendarLocalDataSource,
@@ -42,6 +41,7 @@ class MainCalendarViewModel @Inject constructor(
     val calendarList = calendarLocalDataSource.fetchAllCalendar()
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
+    @ExperimentalCoroutinesApi
     val calendarSetList = calendarId.flatMapLatest { calendarId ->
         checkPointLocalDataSource.fetchCalendarCheckPoints(calendarId)
             .map { checkPointList ->
@@ -49,6 +49,7 @@ class MainCalendarViewModel @Inject constructor(
             }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
+    @ExperimentalCoroutinesApi
     val scheduleList = calendarId.flatMapLatest { calendarId ->
         scheduleLocalDataSource.fetchCalendarSchedules(calendarId)
             .map { scheduleList ->

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -50,6 +50,9 @@ class MainCalendarViewModel @Inject constructor(
     private val _selectedCalendarIndex = MutableStateFlow(0)
     val selectCalendarIndex: StateFlow<Int> = _selectedCalendarIndex
 
+    private val _isMonthCalendar = MutableStateFlow(true)
+    val isMonthCalendar: StateFlow<Boolean> = _isMonthCalendar
+
     private val _fabClickEvent = MutableSharedFlow<Long>()
     val fabClickEvent: SharedFlow<Long> = _fabClickEvent
 
@@ -143,5 +146,9 @@ class MainCalendarViewModel @Inject constructor(
 
     fun setCalendarId(calendarId: Long) {
         savedStateHandle.set(KEY_CALENDAR_ID, calendarId)
+    }
+
+    fun toggleCalendar() {
+        _isMonthCalendar.value = !_isMonthCalendar.value
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -100,7 +100,7 @@ class MainCalendarViewModel @Inject constructor(
     }
 
     private fun CheckPoint.toCalendarSet() = CalendarSet(
-        id = id.toInt(),
+        id = this@MainCalendarViewModel.calendarId.value.toInt(),
         name = name,
         startDate = startDate,
         endDate = endDate

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -42,22 +42,19 @@ class MainCalendarViewModel @Inject constructor(
     val calendarList = calendarLocalDataSource.fetchAllCalendar()
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val scheduleList: StateFlow<List<CalendarScheduleObject>> = calendarId.flatMapLatest { calendarId ->
+    val scheduleList = calendarId.flatMapLatest { calendarId ->
         scheduleLocalDataSource.fetchCalendarSchedules(calendarId)
             .map { scheduleList ->
                 scheduleList.map { schedule -> schedule.mapToCalendarScheduleObject() }
             }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    val calendarSetList: StateFlow<List<CalendarSet>> = calendarId.flatMapLatest { calendarId ->
+    val calendarSetList = calendarId.flatMapLatest { calendarId ->
         checkPointLocalDataSource.fetchCalendarCheckPoints(calendarId)
             .map { checkPointList ->
                 checkPointList.map { checkPoint -> checkPoint.toCalendarSet() }
             }
     }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
-
-    private val _selectedCalendarIndex = MutableStateFlow(0)
-    val selectCalendarIndex: StateFlow<Int> = _selectedCalendarIndex
 
     private val _isMonthCalendar = MutableStateFlow(true)
     val isMonthCalendar: StateFlow<Boolean> = _isMonthCalendar
@@ -101,12 +98,6 @@ class MainCalendarViewModel @Inject constructor(
         startDate = startDate,
         endDate = endDate
     )
-
-    fun setSelectedCalendarIndex(index: Int) {
-        viewModelScope.launch {
-            _selectedCalendarIndex.emit(index)
-        }
-    }
 
     fun emitLicenseClickEvent() {
         viewModelScope.launch {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -27,7 +27,7 @@ class MainCalendarViewModel @Inject constructor(
     private val calendarLocalDataSource: CalendarLocalDataSource,
     private val checkPointLocalDataSource: CheckPointLocalDataSource,
     private val scheduleLocalDataSource: ScheduleLocalDataSource,
-    private val calendarThemeDataSource: CalendarThemeLocalDataSource
+    calendarThemeDataSource: CalendarThemeLocalDataSource
 ) : ViewModel() {
 
     val calendarId = savedStateHandle.getLiveData<Long>(KEY_CALENDAR_ID)
@@ -52,6 +52,10 @@ class MainCalendarViewModel @Inject constructor(
 
     private val _isMonthCalendar = MutableStateFlow(true)
     val isMonthCalendar: StateFlow<Boolean> = _isMonthCalendar
+
+    val calendarDesignObject = calendarThemeDataSource.fetchCalendarTheme()
+        .map { it.toCalendarDesignObject() }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val _fabClickEvent = MutableSharedFlow<Long>()
     val fabClickEvent: SharedFlow<Long> = _fabClickEvent
@@ -134,9 +138,6 @@ class MainCalendarViewModel @Inject constructor(
             _selectedCalendarIndex.emit(index)
         }
     }
-
-    fun fetchCalendarDesignObject() = calendarThemeDataSource.fetchCalendarTheme()
-        .map { it.toCalendarDesignObject() }
 
     fun emitLicenseClickEvent() {
         viewModelScope.launch {

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/maincalendar/MainCalendarViewModel.kt
@@ -74,7 +74,7 @@ class MainCalendarViewModel @Inject constructor(
 
     fun setCalendar(calendar: Calendar) {
         viewModelScope.launch {
-            createCalendarSetList(calendar.id, fetchCheckPointList(calendar.id))
+//            createCalendarSetList(calendar.id, fetchCheckPointList(calendar.id))
         }
     }
 

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.FragmentManageCalendarBinding
 import com.drunkenboys.calendarun.ui.base.BaseFragment
+import com.drunkenboys.calendarun.ui.maincalendar.MainCalendarViewModel
 import com.drunkenboys.calendarun.ui.managecalendar.model.CalendarItem
 import com.drunkenboys.calendarun.util.HorizontalInsetDividerDecoration
 import com.drunkenboys.calendarun.util.extensions.launchAndRepeatWithViewLifecycle
@@ -21,6 +22,7 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
     private val manageCalendarAdapter = ManageCalendarAdapter(::onCalendarItemClickListener)
 
     private val manageCalendarViewModel by navGraphViewModels<ManageCalendarViewModel>(R.id.manageCalendarFragment) { defaultViewModelProviderFactory }
+    private val mainCalendarViewModel by navGraphViewModels<MainCalendarViewModel>(R.id.mainCalendarFragment) { defaultViewModelProviderFactory }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -87,6 +89,11 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
         manageCalendarViewModel.deleteCalendarEvent.collect {
             val currentCalendarItemList = manageCalendarAdapter.currentList
             manageCalendarViewModel.deleteCalendarItem(currentCalendarItemList)
+
+            val currentCalendarId = mainCalendarViewModel.calendarId.value
+            if (currentCalendarId in currentCalendarItemList.map { it.id }) {
+                mainCalendarViewModel.setCalendarId(1)
+            }
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
@@ -90,8 +90,10 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
             val currentCalendarItemList = manageCalendarAdapter.currentList
             manageCalendarViewModel.deleteCalendarItem(currentCalendarItemList)
 
+            // TODO: 2021-11-25 로직의 위치를 옮기고 싶네요
             val currentCalendarId = mainCalendarViewModel.calendarId.value
-            if (currentCalendarId in currentCalendarItemList.map { it.id }) {
+            val checkedList = currentCalendarItemList.filter { it.check }
+            if (checkedList.any { it.id == currentCalendarId }) {
                 mainCalendarViewModel.setCalendarId(1)
             }
         }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarViewModel.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarViewModel.kt
@@ -10,10 +10,7 @@ import com.drunkenboys.calendarun.data.checkpoint.entity.CheckPoint
 import com.drunkenboys.calendarun.data.checkpoint.local.CheckPointLocalDataSource
 import com.drunkenboys.calendarun.ui.savecalendar.model.CheckPointItem
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
@@ -47,7 +44,7 @@ class SaveCalendarViewModel @Inject constructor(
             calendarName.emit(calendar.name)
 
             val checkPointItemList = mutableListOf<CheckPointItem>()
-            val checkPointList = checkPointLocalDataSource.fetchCalendarCheckPoints(calendarId)
+            val checkPointList = checkPointLocalDataSource.fetchCalendarCheckPoints(calendarId).firstOrNull() ?: return@launch
             checkPointList.forEach { checkPoint ->
                 checkPointItemList.add(
                     CheckPointItem(

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,16 +6,13 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fcv_main_container"
-        android:name="androidx.navigation.fragment.NavHostFragment"
+    <FrameLayout
+        android:id="@+id/layout_main_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/nav_main" />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/drawer_header.xml
+++ b/app/src/main/res/layout/drawer_header.xml
@@ -1,39 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/tv_drawerHeader_setting"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:layout_marginEnd="16dp"
-        android:padding="8dp"
-        app:drawableStartCompat="@drawable/ic_settings"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <TextView
-        android:id="@+id/tv_drawerHeader_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:textSize="20dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_drawerHeader_setting"
-        tools:text="전역일 캘린더" />
+        <variable
+            name="viewModel"
+            type="com.drunkenboys.calendarun.ui.maincalendar.MainCalendarViewModel" />
+    </data>
 
-    <TextView
-        android:id="@+id/tv_drawerHeader_subTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginVertical="8dp"
-        android:text="@string/drawer_calendar_subTitle"
-        android:textSize="14dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@id/tv_drawerHeader_title"
-        app:layout_constraintTop_toBottomOf="@+id/tv_drawerHeader_title" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/tv_drawerHeader_setting"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginEnd="16dp"
+            android:onClick="@{() -> viewModel.emitLicenseClickEvent()}"
+            android:padding="8dp"
+            app:drawableStartCompat="@drawable/ic_settings"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_drawerHeader_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@{viewModel.calendarName}"
+            android:textSize="20dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_drawerHeader_setting"
+            tools:text="전역일 캘린더" />
+
+        <TextView
+            android:id="@+id/tv_drawerHeader_subTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="8dp"
+            android:text="@string/drawer_calendar_subTitle"
+            android:textSize="14dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_drawerHeader_title"
+            app:layout_constraintTop_toBottomOf="@+id/tv_drawerHeader_title" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_main_calendar.xml
+++ b/app/src/main/res/layout/fragment_main_calendar.xml
@@ -6,6 +6,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="mainCalendarViewModel"
             type="com.drunkenboys.calendarun.ui.maincalendar.MainCalendarViewModel" />
@@ -43,7 +45,7 @@
                 android:id="@+id/calendar_year"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:visibility="gone"
+                android:visibility="@{mainCalendarViewModel.isMonthCalendar() ? View.GONE : View.VISIBLE}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
@@ -53,6 +55,7 @@
                 android:id="@+id/calendar_month"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
+                android:visibility="@{mainCalendarViewModel.isMonthCalendar() ? View.VISIBLE : View.GONE}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_main_calendar.xml
+++ b/app/src/main/res/layout/fragment_main_calendar.xml
@@ -33,7 +33,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="?actionBarSize"
                     app:menu="@menu/menu_main_calendar_toolbar"
-                    app:title="@{mainCalendarViewModel.calendar.name}"
+                    app:title="@{mainCalendarViewModel.calendarName}"
                     app:titleTextColor="@color/white"
                     tools:title="수능 캘린더" />
 

--- a/app/src/main/res/layout/fragment_main_calendar.xml
+++ b/app/src/main/res/layout/fragment_main_calendar.xml
@@ -49,7 +49,8 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/layout_mainCalendar_toolbar" />
+                app:layout_constraintTop_toBottomOf="@+id/layout_mainCalendar_toolbar"
+                app:onDaySecondClick="@{(date, position) -> mainCalendarViewModel.emitDaySecondClickEvent(date)}" />
 
             <com.drunkenboys.ckscalendar.monthcalendar.MonthCalendarView
                 android:id="@+id/calendar_month"
@@ -59,7 +60,8 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/layout_mainCalendar_toolbar" />
+                app:layout_constraintTop_toBottomOf="@+id/layout_mainCalendar_toolbar"
+                app:onDaySecondClick="@{(date, position) -> mainCalendarViewModel.emitDaySecondClickEvent(date)}" />
 
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/fab_mainCalender_addSchedule"

--- a/app/src/main/res/menu/menu_main_calendar_nav_drawer.xml
+++ b/app/src/main/res/menu/menu_main_calendar_nav_drawer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_mainCalendar_addCalendar"
+        android:icon="@drawable/ic_add"
+        android:title="@string/calendar_add"
+        app:showAsAction="ifRoom" />
+    <group android:id="@+id/menuGroup_mainCalendar_calendarManage">
+        <item
+            android:id="@+id/menuSubtitl_mainCalendar_calendarManage"
+            android:title="@string/drawer_calendar_manage">
+            <menu>
+                <item
+                    android:id="@+id/menu_mainCalendar_calendarManage"
+                    android:icon="@drawable/ic_calendar_today"
+                    android:title="@string/drawer_calendar_manage"
+                    app:showAsAction="ifRoom" />
+                <item
+                    android:id="@+id/menu_mainCalendar_themeSetting"
+                    android:icon="@drawable/ic_palette"
+                    android:title="@string/drawer_theme_setting"
+                    app:showAsAction="ifRoom" />
+                <item
+                    android:id="@+id/menu_mainCalendar_license"
+                    android:icon="@drawable/ic_license"
+                    android:title="@string/drawer_license"
+                    app:showAsAction="ifRoom" />
+            </menu>
+        </item>
+    </group>
+</menu>

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -43,6 +43,9 @@
         <action
             android:id="@+id/to_themeFragment"
             app:destination="@id/themeFragment" />
+        <argument
+            android:name="calendarId"
+            app:argType="long" />
     </fragment>
 
     <fragment

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeCalendarLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.drunkenboys.calendarun.data.schedule.local
 
 import com.drunkenboys.calendarun.data.calendar.entity.Calendar
 import com.drunkenboys.calendarun.data.calendar.local.CalendarLocalDataSource
+import kotlinx.coroutines.flow.Flow
 import java.time.LocalDate
 
 class FakeCalendarLocalDataSource : CalendarLocalDataSource {
@@ -10,7 +11,7 @@ class FakeCalendarLocalDataSource : CalendarLocalDataSource {
         TODO("Not yet implemented")
     }
 
-    override suspend fun fetchAllCalendar(): List<Calendar> {
+    override fun fetchAllCalendar(): Flow<List<Calendar>> {
         TODO("Not yet implemented")
     }
 

--- a/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
+++ b/app/src/test/java/com/drunkenboys/calendarun/data/schedule/local/FakeScheduleLocalDataSource.kt
@@ -2,6 +2,8 @@ package com.drunkenboys.calendarun.data.schedule.local
 
 import com.drunkenboys.calendarun.data.schedule.entity.Schedule
 import com.drunkenboys.calendarun.util.defaultZoneOffset
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class FakeScheduleLocalDataSource : ScheduleLocalDataSource {
 
@@ -20,8 +22,8 @@ class FakeScheduleLocalDataSource : ScheduleLocalDataSource {
         return database.find { it.id == id } ?: throw IllegalArgumentException()
     }
 
-    override suspend fun fetchCalendarSchedules(calendarId: Long): List<Schedule> {
-        return database.filter { it.calendarId == calendarId }
+    override fun fetchCalendarSchedules(calendarId: Long): Flow<List<Schedule>> {
+        return flow { database.filter { it.calendarId == calendarId } }
     }
 
     override suspend fun updateSchedule(schedule: Schedule) {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/monthcalendar/MonthCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/monthcalendar/MonthCalendarView.kt
@@ -49,6 +49,7 @@ class MonthCalendarView @JvmOverloads constructor(
     private val today = LocalDate.now()
 
     private var hasRestore = false
+    private var lastCalendarType = MonthState.CalendarType.NONE
     private var lastPagePosition = -1
     private var lastPageName = ""
 
@@ -112,13 +113,13 @@ class MonthCalendarView @JvmOverloads constructor(
         pageAdapter.setItems(calendarList, false)
         binding.tvMonthCalendarViewCurrentMonth.text = calendarList.first().name
         hasRestore = false
+        lastCalendarType = MonthState.CalendarType.CUSTOM
     }
 
     fun setupDefaultCalendarSet() {
         calendarList = CalendarSet.generateCalendarOfYear(context, today.year)
         pageAdapter.setItems(calendarList, true)
-
-        if (hasRestore) {
+        if (hasRestore && lastCalendarType == MonthState.CalendarType.DEFAULT) {
             hasRestore = false
             binding.vpMonthPage.setCurrentItem(lastPagePosition, false)
             binding.tvMonthCalendarViewCurrentMonth.text = lastPageName
@@ -132,6 +133,7 @@ class MonthCalendarView @JvmOverloads constructor(
                 }
             }
         }
+        lastCalendarType = MonthState.CalendarType.DEFAULT
     }
 
     fun setOnDayClickListener(onDayClickListener: OnDayClickListener) {
@@ -169,7 +171,7 @@ class MonthCalendarView @JvmOverloads constructor(
 
     override fun onSaveInstanceState(): Parcelable? {
         val parcelable = super.onSaveInstanceState() ?: return null
-        return MonthState(parcelable, lastPageName, lastPagePosition)
+        return MonthState(parcelable, lastPageName, lastPagePosition, lastCalendarType)
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {
@@ -178,6 +180,7 @@ class MonthCalendarView @JvmOverloads constructor(
                 super.onRestoreInstanceState(state.superState)
                 lastPagePosition = state.lastPagePosition
                 lastPageName = state.lastPageName
+                lastCalendarType = state.lastCalendarType
                 hasRestore = true
             }
             else -> super.onRestoreInstanceState(state)

--- a/library/src/main/java/com/drunkenboys/ckscalendar/monthcalendar/MonthState.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/monthcalendar/MonthState.kt
@@ -8,6 +8,11 @@ import kotlinx.parcelize.Parcelize
 class MonthState(
     val parcelable: Parcelable,
     val lastPageName: String = "",
-    val lastPagePosition: Int = -1
+    val lastPagePosition: Int = -1,
+    val lastCalendarType: CalendarType = CalendarType.NONE
 ) : View.BaseSavedState(parcelable) {
+
+    enum class CalendarType {
+        DEFAULT, CUSTOM, NONE
+    }
 }


### PR DESCRIPTION
## what is this pr
MainCalendar 페이지의 데이터 흐름을 반응형으로 변경함.

Resolve: #271

## Changes
- 데이터 쿼리를 Flow를 사용한 반응형 쿼리로 변경
- 캘린더 삭제 시 Drawer의 캘린더 체크가 동작하지 않는 버그 수정
- 메뉴 초기화 방식 수정
- 마지막으로 선택한 캘린더 저장

