### PR TITLE
연달력 상태저장

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -66,7 +66,8 @@ fun LazyListState.InitScroll(
         derivedStateOf {
             with(layoutInfo) {
                 val firstIndex = visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
-                firstVisibleItemIndex + Period.between(firstIndex.key as LocalDate, clickedDay).months
+                val between = Period.between(firstIndex.key as LocalDate, clickedDay)
+                firstVisibleItemIndex +  between.months + between.years * 12
             }
         }
     }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -3,6 +3,8 @@ package com.drunkenboys.ckscalendar.utils
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.*
 import kotlinx.coroutines.flow.collect
+import java.time.LocalDate
+import java.time.Period
 
 // 참고: https://ichi.pro/ko/jetpack-compose-ui-muhan-moglog-peiji-moglog-194681336448872
 @Composable
@@ -52,6 +54,26 @@ fun LazyListState.ShouldPrevScroll(
         // collect
         snapshotFlow { shouldLoadMore.value }.collect { should ->
             if (should) { onLoadMore() }
+        }
+    }
+}
+
+@Composable
+fun LazyListState.InitScroll(
+    clickedDay: LocalDate
+) {
+    val scroll = remember {
+        derivedStateOf {
+            with(layoutInfo) {
+                val firstIndex = visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
+                firstVisibleItemIndex + Period.between(firstIndex.key as LocalDate, clickedDay).months
+            }
+        }
+    }
+
+    LaunchedEffect(scroll) {
+        snapshotFlow { scroll.value }.collect { index ->
+            scrollToItem(index)
         }
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -74,7 +74,7 @@ fun LazyListState.InitScroll(
 
     LaunchedEffect(scroll) {
         snapshotFlow { scroll.value }.collect { index ->
-            scrollToItem(index)
+            if (index > 0) scrollToItem(index)
         }
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarView.kt
@@ -124,8 +124,6 @@ class YearCalendarView
         // TODO: 원하는 날짜로 클릭
     }
 
-    fun findClickedDay(): LocalDate? = viewModel.clickedDay.value
-
     fun getDaySchedules(day: LocalDateTime): List<CalendarScheduleObject> = viewModel.getDaySchedules(day)
 
     fun setCalendarSetList(calendarSetList: List<CalendarSet>) {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -1,9 +1,6 @@
 package com.drunkenboys.ckscalendar.yearcalendar
 
-import android.util.Log
 import androidx.compose.runtime.*
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.drunkenboys.ckscalendar.data.*
 import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -9,7 +9,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-class YearCalendarViewModel: ViewModel() {
+class YearCalendarViewModel {
 
     private val _schedules = mutableStateOf<List<CalendarScheduleObject>>(emptyList())
     val schedules: State<List<CalendarScheduleObject>> = _schedules
@@ -19,9 +19,6 @@ class YearCalendarViewModel: ViewModel() {
 
     private var _calendar = mutableStateOf(createCalendarSets(LocalDate.now().year))
     val calendar: State<List<CalendarSet>> = _calendar
-
-    private val _clickedDay = mutableStateOf<LocalDate?>(LocalDate.now())
-    val clickedDay: State<LocalDate?> = _clickedDay
 
     private val _scrollPosition = mutableStateOf(12 + LocalDate.now().monthValue)
     val scrollPosition: State<Int> = _scrollPosition
@@ -95,10 +92,6 @@ class YearCalendarViewModel: ViewModel() {
         day.date == month.startDate && day.dayType != DayType.PADDING
     }
 
-    fun clickDay(day: CalendarDate) {
-        _clickedDay.value = day.date
-    }
-
     fun getDaySchedules(day: LocalDateTime) = schedules.value.filter { schedule ->
         day in schedule.startDate..schedule.endDate
     }
@@ -145,8 +138,5 @@ class YearCalendarViewModel: ViewModel() {
         fetchPrevCalendarSet()
         _calendar.value = createCalendarSets(LocalDate.now().year)
         fetchNextCalendarSet()
-
-        // 오늘 선택
-        _clickedDay.value = LocalDate.now()
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -20,9 +20,6 @@ class YearCalendarViewModel {
     private var _calendar = mutableStateOf(createCalendarSets(LocalDate.now().year))
     val calendar: State<List<CalendarSet>> = _calendar
 
-    private val _scrollPosition = mutableStateOf(12 + LocalDate.now().monthValue)
-    val scrollPosition: State<Int> = _scrollPosition
-
     private var recomposeScope: RecomposeScope? = null
 
     fun setRecomposeScope(recompose: RecomposeScope) {
@@ -45,15 +42,6 @@ class YearCalendarViewModel {
 
     fun setDefaultDesign() {
         _design.value = CalendarDesignObject.getDefaultDesign()
-    }
-
-    // FIXME: 체크포인트 속에서 오늘의 날짜 찾기
-    fun getDayScrollPosition(day: LocalDate = LocalDate.now()): Int {
-        return day.monthValue
-    }
-
-    fun setScrollPosition(index: Int) {
-        _scrollPosition.value = index
     }
 
     fun setWeekSchedules(

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -1,7 +1,9 @@
 package com.drunkenboys.ckscalendar.yearcalendar
 
-import androidx.compose.foundation.lazy.LazyListState
+import android.util.Log
 import androidx.compose.runtime.*
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.drunkenboys.ckscalendar.data.*
 import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
@@ -24,7 +26,7 @@ class YearCalendarViewModel: ViewModel() {
     private val _clickedDay = mutableStateOf<LocalDate?>(LocalDate.now())
     val clickedDay: State<LocalDate?> = _clickedDay
 
-    private val _scrollPosition = mutableStateOf(0)
+    private val _scrollPosition = mutableStateOf(12 + LocalDate.now().monthValue)
     val scrollPosition: State<Int> = _scrollPosition
 
     private var recomposeScope: RecomposeScope? = null
@@ -54,6 +56,10 @@ class YearCalendarViewModel: ViewModel() {
     // FIXME: 체크포인트 속에서 오늘의 날짜 찾기
     fun getDayScrollPosition(day: LocalDate = LocalDate.now()): Int {
         return day.monthValue
+    }
+
+    fun setScrollPosition(index: Int) {
+        _scrollPosition.value = index
     }
 
     fun setWeekSchedules(

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/YearCalendarViewModel.kt
@@ -1,5 +1,6 @@
 package com.drunkenboys.ckscalendar.yearcalendar
 
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.*
 import androidx.lifecycle.ViewModel
 import com.drunkenboys.ckscalendar.data.*
@@ -22,6 +23,9 @@ class YearCalendarViewModel: ViewModel() {
 
     private val _clickedDay = mutableStateOf<LocalDate?>(LocalDate.now())
     val clickedDay: State<LocalDate?> = _clickedDay
+
+    private val _scrollPosition = mutableStateOf(0)
+    val scrollPosition: State<Int> = _scrollPosition
 
     private var recomposeScope: RecomposeScope? = null
 
@@ -48,7 +52,7 @@ class YearCalendarViewModel: ViewModel() {
     }
 
     // FIXME: 체크포인트 속에서 오늘의 날짜 찾기
-    fun getDayItemIndex(day: LocalDate = LocalDate.now()): Int {
+    fun getDayScrollPosition(day: LocalDate = LocalDate.now()): Int {
         return day.monthValue
     }
 

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.drunkenboys.ckscalendar.data.*
 import com.drunkenboys.ckscalendar.listener.OnDayClickListener
 import com.drunkenboys.ckscalendar.listener.OnDaySecondClickListener
+import com.drunkenboys.ckscalendar.utils.InitScroll
 import com.drunkenboys.ckscalendar.utils.ShouldNextScroll
 import com.drunkenboys.ckscalendar.utils.ShouldPrevScroll
 import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
@@ -41,7 +42,6 @@ fun CalendarLazyColumn(
     val listState = rememberLazyListState()
     val calendar by remember { viewModel.calendar }
     var clickedDay by rememberSaveable { mutableStateOf(LocalDate.now()) }
-    val scrollPosition by rememberSaveable { viewModel.scrollPosition }
 
     // state hoisting
     val dayColumnModifier = { day: CalendarDate ->
@@ -74,11 +74,6 @@ fun CalendarLazyColumn(
 
     // setSchedule 호출 시 recompose할 Scope 전달
     viewModel.setRecomposeScope(currentRecomposeScope)
-
-    // 종료를 감지
-
-//    viewModel.setScrollPosition(listState.layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: 15)
-
 
     // RecyclerView와 유사
     LazyColumn(
@@ -113,17 +108,16 @@ fun CalendarLazyColumn(
         }
     }
 
-    // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
-    LaunchedEffect(listState) {
-        listState.scrollToItem(index = scrollPosition)
-    }
+    with(listState) {
+        InitScroll(clickedDay = clickedDay)
 
-    listState.ShouldNextScroll {
-        viewModel.fetchNextCalendarSet()
-    }
+        ShouldNextScroll {
+            viewModel.fetchNextCalendarSet()
+        }
 
-    listState.ShouldPrevScroll {
-        viewModel.fetchPrevCalendarSet()
+        ShouldPrevScroll {
+            viewModel.fetchPrevCalendarSet()
+        }
     }
 }
 

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
@@ -38,8 +39,8 @@ fun CalendarLazyColumn(
 ) {
     // RecyclerView의 상태를 관찰
     val listState = rememberLazyListState()
-    val calendar by remember { viewModel.calendar }
-    val clickedDay by remember { viewModel.clickedDay }
+    val calendar by rememberSaveable { viewModel.calendar }
+    val clickedDay by rememberSaveable { viewModel.clickedDay }
 
     // state hoisting
     val dayColumnModifier = { day: CalendarDate ->

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -1,6 +1,5 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
-import android.util.Log
 import android.view.Gravity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -16,7 +15,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,14 +40,12 @@ fun CalendarLazyColumn(
     // RecyclerView의 상태를 관찰
     val listState = rememberLazyListState()
     val calendar by remember { viewModel.calendar }
-    val clickedDay by rememberSaveable { viewModel.clickedDay }
+    var clickedDay by rememberSaveable { mutableStateOf(LocalDate.now()) }
     val scrollPosition by rememberSaveable { viewModel.scrollPosition }
 
     // state hoisting
     val dayColumnModifier = { day: CalendarDate ->
-
         when (clickedDay) {
-
             day.date -> {
                 Modifier
                     .layoutId(day.date.toString())
@@ -70,7 +66,7 @@ fun CalendarLazyColumn(
                     )
                     .clickable(onClick = {
                         onDayClickListener?.onDayClick(day.date, 0)
-                        viewModel.clickDay(day)
+                        clickedDay = day.date
                     })
             }
         }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -41,7 +41,7 @@ fun CalendarLazyColumn(
 ) {
     // RecyclerView의 상태를 관찰
     val listState = rememberLazyListState()
-    val calendar by rememberSaveable { viewModel.calendar }
+    val calendar by remember { viewModel.calendar }
     val clickedDay by rememberSaveable { viewModel.clickedDay }
     val scrollPosition by rememberSaveable { viewModel.scrollPosition }
 

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -1,5 +1,6 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
+import android.util.Log
 import android.view.Gravity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -15,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -77,6 +79,11 @@ fun CalendarLazyColumn(
     // setSchedule 호출 시 recompose할 Scope 전달
     viewModel.setRecomposeScope(currentRecomposeScope)
 
+    // 종료를 감지
+
+//    viewModel.setScrollPosition(listState.layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: 15)
+
+
     // RecyclerView와 유사
     LazyColumn(
         state = listState,
@@ -112,7 +119,7 @@ fun CalendarLazyColumn(
 
     // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
     LaunchedEffect(listState) {
-        listState.scrollToItem(index = viewModel.getDayScrollPosition())
+        listState.scrollToItem(index = scrollPosition)
     }
 
     listState.ShouldNextScroll {

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -41,6 +41,7 @@ fun CalendarLazyColumn(
     val listState = rememberLazyListState()
     val calendar by rememberSaveable { viewModel.calendar }
     val clickedDay by rememberSaveable { viewModel.clickedDay }
+    val scrollPosition by rememberSaveable { viewModel.scrollPosition }
 
     // state hoisting
     val dayColumnModifier = { day: CalendarDate ->
@@ -111,7 +112,7 @@ fun CalendarLazyColumn(
 
     // 뷰가 호출되면 오늘 날짜가 보이게 스크롤
     LaunchedEffect(listState) {
-        listState.scrollToItem(index = viewModel.getDayItemIndex())
+        listState.scrollToItem(index = viewModel.getDayScrollPosition())
     }
 
     listState.ShouldNextScroll {


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Related #278 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->

- 클릭 상태 저장
  - 클릭된 날짜는 디폴트로 LocalDate.now()이고 null이 될 수 없음
- 뷰 재생성 시 클릭된 날짜로 스크롤
  - (클릭된 날짜.month - 생성 화면의 첫 날짜.month) 만큼 스크롤함.
  - 슬라이스에서는 부정확하고, 기본 캘린더에서는 무한스크롤의 fetch와 맞물려 1년의 오차가 생길 때가 있음.
  - 버벅임이 있기 때문에 merge를 해도 될지 모르겠음
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/143799912-cc2957c7-c6ff-471d-94cc-2e2f0e717467.gif" width=350 />
