### PR TITLE
연달력 일정 시작 패딩

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -1,10 +1,7 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
@@ -33,28 +30,22 @@ fun ScheduleText(
     viewModel.setWeekSchedules(weekScheduleList, today)
 
     weekScheduleList[today.dayOfWeek.dayValue()].forEach { schedule ->
-        Text(
-            text = if (schedule != null && (schedule.startDate.toLocalDate() == today || today.dayOfWeek == DayOfWeek.SUNDAY))
-                schedule.text else " ",
-            maxLines = 1,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = if (schedule != null) Color(schedule.color) else Color.Transparent,
-                    shape = when {
-                        schedule != null && (schedule.endDate.toLocalDate() == today) ->
-                            RoundedCornerShape(topEnd = 20.dp, bottomEnd = 20.dp)
-                        schedule != null && (schedule.startDate.toLocalDate() == today) ->
-                            RoundedCornerShape(topStart = 20.dp, bottomStart = 20.dp)
-                        else ->
-                            RectangleShape
-                    }
-                )
-                .padding(4.dp),
-            overflow = TextOverflow.Ellipsis,
-            fontSize = viewModel.design.value.textSize.dp(),
-            color = Color.White
-        )
+        Row {
+            if (schedule != null && (schedule.startDate.toLocalDate() == today)) Spacer(modifier = Modifier.width(10.dp))
+
+            Text(
+                text = if (schedule != null && (schedule.startDate.toLocalDate() == today || today.dayOfWeek == DayOfWeek.SUNDAY))
+                    schedule.text else " ",
+                maxLines = 1,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = if (schedule != null) Color(schedule.color) else Color.Transparent)
+                    .padding(4.dp),
+                overflow = TextOverflow.Ellipsis,
+                fontSize = viewModel.design.value.textSize.dp(),
+                color = Color.White
+            )
+        }
         Spacer(modifier = Modifier.height(2.dp))
     }
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -2,13 +2,10 @@ package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CutCornerShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -24,29 +24,17 @@ fun ScheduleText(
     weekScheduleList: Array<Array<CalendarScheduleObject?>>,
     viewModel: YearCalendarViewModel
 ) {
-    val weekNum = (today.dayOfWeek.dayValue())
-
-    val scheduleText = { schedule: CalendarScheduleObject? ->
-        when {
-            schedule == null -> " "
-            schedule.startDate.toLocalDate() == today || today.dayOfWeek == DayOfWeek.SUNDAY -> schedule.text
-            else -> " "
-        }
-    }
-
-    val color = { schedule: CalendarScheduleObject? ->
-        if (schedule != null) Color(schedule.color) else Color.Transparent
-    }
-
     viewModel.setWeekSchedules(weekScheduleList, today)
 
-    weekScheduleList[weekNum].forEach { schedule ->
+    weekScheduleList[today.dayOfWeek.dayValue()].forEach { schedule ->
         Text(
-            text = scheduleText(schedule),
+            text = if (schedule != null && (schedule.startDate.toLocalDate() == today || today.dayOfWeek == DayOfWeek.SUNDAY))
+                schedule.text else " ",
             maxLines = 1,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = color(schedule)).padding(4.dp),
+                .background(color = if (schedule != null) Color(schedule.color) else Color.Transparent)
+                .padding(4.dp),
             overflow = TextOverflow.Ellipsis,
             fontSize = viewModel.design.value.textSize.dp(),
             color = Color.White

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
+import com.drunkenboys.ckscalendar.utils.TimeUtils
 import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
 import com.drunkenboys.ckscalendar.utils.dp
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Composable
 fun ScheduleText(
@@ -55,4 +57,21 @@ fun ScheduleText(
         )
         Spacer(modifier = Modifier.height(2.dp))
     }
+}
+
+@Preview
+@Composable
+fun PreviewSchedule() {
+    val viewModel = YearCalendarViewModel()
+    ScheduleText(
+        today = LocalDate.now(),
+        weekScheduleList =  Array(7) { Array(viewModel.design.value.visibleScheduleCount) { CalendarScheduleObject(
+            id = 1,
+            color = TimeUtils.getColorInt(255, 0, 0),
+            text = "test",
+            startDate = LocalDateTime.now(),
+            endDate = LocalDateTime.now()
+        ) } },
+        viewModel = viewModel
+    )
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/ScheduleText.kt
@@ -5,11 +5,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.drunkenboys.ckscalendar.data.CalendarScheduleObject
 import com.drunkenboys.ckscalendar.utils.TimeUtils.dayValue
@@ -33,7 +37,17 @@ fun ScheduleText(
             maxLines = 1,
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = if (schedule != null) Color(schedule.color) else Color.Transparent)
+                .background(
+                    color = if (schedule != null) Color(schedule.color) else Color.Transparent,
+                    shape = when {
+                        schedule != null && (schedule.endDate.toLocalDate() == today) ->
+                            RoundedCornerShape(topEnd = 20.dp, bottomEnd = 20.dp)
+                        schedule != null && (schedule.startDate.toLocalDate() == today) ->
+                            RoundedCornerShape(topStart = 20.dp, bottomStart = 20.dp)
+                        else ->
+                            RectangleShape
+                    }
+                )
                 .padding(4.dp),
             overflow = TextOverflow.Ellipsis,
             fontSize = viewModel.design.value.textSize.dp(),


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #288 

## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 일정 시작 시 패딩

## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img width="350" alt="스크린샷 2021-11-29 오후 6 31 05" src="https://user-images.githubusercontent.com/55696672/143842553-c41caa25-d265-430d-b87a-cd56889c91cc.png">

