### PR TITLE
연달력 일정을 덮는 테두리버그 수정

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -17,6 +17,10 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.style.TextAlign
@@ -48,7 +52,6 @@ fun CalendarLazyColumn(
         when (clickedDay) {
             day.date -> {
                 Modifier
-                    .layoutId(day.date.toString())
                     .border(
                         border = BorderStroke(width = 2.dp, color = Color(viewModel.design.value.selectedFrameColor)),
                         shape = RoundedCornerShape(6.dp)
@@ -60,10 +63,6 @@ fun CalendarLazyColumn(
 
             else -> {
                 Modifier
-                    .layoutId(day.date.toString())
-                    .border(
-                        border = BorderStroke(width = 0.1f.dp, color = Color(viewModel.design.value.weekDayTextColor).copy(alpha = 0.1f))
-                    )
                     .clickable(onClick = {
                         onDayClickListener?.onDayClick(day.date, 0)
                         clickedDay = day.date

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -83,13 +83,12 @@ fun CalendarLazyColumn(
     ) {
         items(calendar, key = { slice -> slice.startDate }) { slice ->
 
-            val firstOfYear = LocalDate.of(slice.endDate.year, 1, 1)
+            val firstOfYear = LocalDate.of(slice.startDate.year, 1, 1)
 
             // 해가 갱신될 때마다 상단에 연표시
-            if (firstOfYear in slice.startDate..slice.endDate) {
-
+            if (firstOfYear in slice.startDate..slice.endDate || firstOfYear.plusYears(1L) in slice.startDate..slice.endDate) {
                 Text(
-                    text = "${firstOfYear.year}년",
+                    text = "${slice.startDate.year}년",
                     color = MaterialTheme.colors.primary,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
@@ -36,7 +36,6 @@ fun MonthCalendar(
     calendarSetToCalendarDatesList(month).forEach { week ->
         weekSchedules = Array(7) { Array(viewModel.design.value.visibleScheduleCount) { null } }
         // 1주일
-        // 연 표시
         ConstraintLayout(
             constraintSet = dayOfWeekConstraints(week.map { day -> day.date.toString() }),
             modifier = Modifier.fillMaxWidth()

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/MonthCalendar.kt
@@ -1,16 +1,16 @@
 package com.drunkenboys.ckscalendar.yearcalendar.composeView
 
 import android.view.Gravity
-import android.widget.Space
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,7 +62,19 @@ fun MonthCalendar(
 
                     // 1일
                     else -> Column(
-                        modifier = dayColumnModifier(day),
+                        modifier = Modifier.layoutId(day.date.toString())
+                            .then(dayColumnModifier(day))
+                            .drawBehind {
+                                drawLine(start = Offset(0f, 0f),
+                                    end = Offset(size.width, 0f),
+                                    color = Color.Black.copy(alpha = 0.1f))
+                                drawLine(start = Offset(size.width, 0f),
+                                    end = Offset(size.width, size.height),
+                                    color = Color.Black.copy(alpha = 0.1f))
+                                drawLine(start = Offset(size.width, size.height),
+                                    end = Offset(0f, size.height),
+                                    color = Color.Black.copy(alpha = 0.1f))
+                            },
                         horizontalAlignment = GravityMapper.toColumnAlign(viewModel.design.value.textAlign)
                     ) {
                         DayText(


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve #290 
Resolve: #305 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 사각형은 두 날짜의 선분이 겹치며 스케줄을 뚫고 선분을 하나 보여줌
- 한 cell당 drawLine을 세 개 그리는 것으로 해결

- 기존 연 표시 로직: endDate의 1월1일이 포함되면 해당 년도 표시
- 변경 연 표시 로직: startDate의 1월 1일 or (startDate + 1년)의 1월 1일이 포함되면 startDate년도 표시
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->

<img width="350" alt="스크린샷 2021-11-30 오전 12 06 37" src="https://user-images.githubusercontent.com/55696672/143892296-f2b3b5ba-9042-4b1b-b415-a3f3b6e64bb5.png">

반박시 착시현상
<img width="350" alt="스크린샷 2021-11-29 오후 11 49 50" src="https://user-images.githubusercontent.com/55696672/143892317-3d1dfe78-0150-4ba9-960c-10137b1eb361.png">

