### PR TITLE
연달력 스크롤 기능 수정

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -67,7 +67,7 @@ fun LazyListState.InitScroll(
             with(layoutInfo) {
                 val firstIndex = visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
                 val between = Period.between(firstIndex.key as LocalDate, clickedDay)
-                firstVisibleItemIndex +  between.months + between.years * 12
+                firstVisibleItemIndex + (between.years * 12 * 30 + between.months * 30 + between.days) / 7
             }
         }
     }


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve #278 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 뷰 첫 생성 시에만 오늘 날짜로 자동 스크롤 <- 간헐적으로 다른 상황에서도 자동 스크롤됨
  - 스크롤이 비동기 동작인데, 재생성시에도 스크롤 될 때가 있음, 1번 호출돼야 하는데 중복 호출될 때도 있음.
  - 슬라이스 안에 오늘 날짜가 없으면 최대한 가까이 이동하고, 오류는 발생하지 않음
- 화면 이동 뒤 복구할 때에는 현재 보고있는 스크롤 유지 
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/144004353-679dec3f-1af8-40e5-aa7e-6179aebd028c.gif" width=350 />
