### PR TITLE
연달력 격자 어긋남 해결

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/WeekCalendar.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/WeekCalendar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -11,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -45,14 +47,26 @@ fun WeekCalendar(
 
         week.forEach { day ->
             when (day.dayType) {
-                // 빈 날짜
                 DayType.PADDING -> Column(
                     modifier = Modifier
                         .layoutId(day.date.toString())
                         .border(border = BorderStroke(width = 0.1f.dp, color = weekDayColor.copy(alpha = 0.1f)))
                 ) {
-                    repeat(viewModel.design.value.visibleScheduleCount + 1) {
-                        Text(text = " ")
+                    // 빈 날짜
+                    Text(
+                        text = "padding",
+                        modifier = Modifier.padding(5.dp),
+                        maxLines = 1,
+                        color = Color.Transparent,
+                    )
+
+                    // 빈 스케줄
+                    repeat(viewModel.design.value.visibleScheduleCount) {
+                        Text(
+                            text = "",
+                            modifier = Modifier,
+                            color = Color.Transparent
+                        )
                     }
                 }
 


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve #316 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 기존: 달력 빈 cell의 날짜에 패딩이 없었음
- 변경: 달력 기존 날짜에 있는 패딩만큼 추가
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/143996939-cb287c92-9661-4911-9d9a-c8dbcf3905de.png" width=350 />
