### PR TITLE
슬라이스, 달력 삭제 버튼 조건에 따라 Visible 변경

### DIFF
--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarAdapter.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarAdapter.kt
@@ -1,15 +1,29 @@
 package com.drunkenboys.calendarun.ui.managecalendar
 
 import android.view.ViewGroup
+import android.widget.CompoundButton
 import androidx.recyclerview.widget.ListAdapter
 import com.drunkenboys.calendarun.BR
 import com.drunkenboys.calendarun.R
 import com.drunkenboys.calendarun.databinding.ItemCalendarBinding
 import com.drunkenboys.calendarun.ui.base.BaseViewHolder
 import com.drunkenboys.calendarun.ui.managecalendar.model.CalendarItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class ManageCalendarAdapter(val onClick: (CalendarItem) -> Unit) :
     ListAdapter<CalendarItem, BaseViewHolder<ItemCalendarBinding>>(CalendarItem.diffUtil) {
+
+    private val _checkedCalendarNum = MutableStateFlow(0)
+    val checkedCalendarNum: StateFlow<Int> = _checkedCalendarNum
+
+    val onCheckedChangeListener = CompoundButton.OnCheckedChangeListener { button, isChecked ->
+        if (isChecked) {
+            _checkedCalendarNum.value++
+        } else {
+            _checkedCalendarNum.value--
+        }
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<ItemCalendarBinding> =
         BaseViewHolder(parent, R.layout.item_calendar)

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/managecalendar/ManageCalendarFragment.kt
@@ -36,6 +36,7 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
         launchAndRepeatWithViewLifecycle {
             launch { collectCalendarItemList() }
             launch { collectDeleteCalendar() }
+            launch { collectCheckedCalendarNum() }
         }
     }
 
@@ -46,7 +47,6 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
 
     private fun setupToolbar() {
         binding.toolbarManageCalendar.setupWithNavController(navController)
-        // TODO: 2021-11-15 메뉴 아이템 클릭 리스너 추가
     }
 
     private fun setupAdapter() {
@@ -98,6 +98,12 @@ class ManageCalendarFragment : BaseFragment<FragmentManageCalendarBinding>(R.lay
             if (checkedList.any { it.id == currentCalendarId }) {
                 mainCalendarViewModel.setCalendarId(1)
             }
+        }
+    }
+
+    private suspend fun collectCheckedCalendarNum() {
+        manageCalendarAdapter.checkedCalendarNum.collect() { nums ->
+            binding.toolbarManageCalendar.menu.findItem(R.id.menu_delete_schedule).isVisible = nums > 0
         }
     }
 }

--- a/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
+++ b/app/src/main/java/com/drunkenboys/calendarun/ui/savecalendar/SaveCalendarFragment.kt
@@ -95,8 +95,11 @@ class SaveCalendarFragment : BaseFragment<FragmentSaveCalendarBinding>(R.layout.
 
     private suspend fun collectUseDefaultCalendar() {
         saveCalendarViewModel.useDefaultCalendar.collect { checked ->
-            binding.rvSaveCalendarCheckPointList.isVisible = !checked
-            binding.tvSaveCalendarAddCheckPointView.isVisible = !checked
+            with(binding) {
+                rvSaveCalendarCheckPointList.isVisible = !checked
+                tvSaveCalendarAddCheckPointView.isVisible = !checked
+                toolbarSaveCalendar.menu.findItem(R.id.menu_delete_checkPoint).isVisible = !checked
+            }
         }
     }
 

--- a/app/src/main/res/layout/item_calendar.xml
+++ b/app/src/main/res/layout/item_calendar.xml
@@ -97,6 +97,7 @@
             android:layout_height="wrap_content"
             android:button="@drawable/selector_check_box_18"
             android:checked="@={item.check}"
+            android:onCheckedChanged="@{adapter.onCheckedChangeListener}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
## what is this pr
달력 추가에서 커스텀 달력 생성일 때만 삭제 메뉴가 보이도록 변경
달력 관리에서 체크된 달력이 있을 때만 삭제 메뉴가 보이도록 변경
Resolve: #320 

## screenshot
<img src="https://user-images.githubusercontent.com/50517813/144051720-31730047-d216-4c30-b7e9-24c511fb7758.gif" width=350 />
<img src="https://user-images.githubusercontent.com/50517813/144051838-ec6ca4cc-baca-4f78-a0da-b6ab7330c624.gif" width=350 />


