### PR TITLE
연달력 날짜 중복 시 크래시 현상 해결

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -3,8 +3,13 @@ package com.drunkenboys.ckscalendar.utils
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.*
 import kotlinx.coroutines.flow.collect
+import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.Period
+import java.util.*
+
+private const val DAY_OF_WEEK = 7
+
+private const val TIME_MILLIS_OF_DAY = 24 * 60 * 60 * 1000
 
 // 참고: https://ichi.pro/ko/jetpack-compose-ui-muhan-moglog-peiji-moglog-194681336448872
 @Composable
@@ -59,15 +64,18 @@ fun LazyListState.ShouldPrevScroll(
 }
 
 @Composable
-fun LazyListState.InitScroll(
-    clickedDay: LocalDate
-) {
+fun LazyListState.InitScroll() {
     val scroll = remember {
         derivedStateOf {
             with(layoutInfo) {
-                val firstIndex = visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
-                val between = Period.between(firstIndex.key as LocalDate, clickedDay)
-                firstVisibleItemIndex + (between.years * 12 * 30 + between.months * 30 + between.days) / 7
+                visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
+
+                /** 이동해야할 스크롤 인덱스
+                 * 1. 인덱스 1당 1주일이 넘어간다.
+                 * 2. 달력의 빈 공간을 채워주기 위해 달이 넘어갈 때마다 비어있는 1주일이 생긴다.
+                 * (오늘 - 달력의 첫날) / 7 + 빈공간
+                  */
+                (getStartDayToToday() / DAY_OF_WEEK / TIME_MILLIS_OF_DAY).toInt() + getPaddingWeeks()
             }
         }
     }
@@ -77,4 +85,33 @@ fun LazyListState.InitScroll(
             if (index > 0) scrollToItem(index)
         }
     }
+}
+
+private fun getStartDayToToday(): Long {
+    val startDay = Calendar.getInstance().apply {
+        set(Calendar.YEAR, LocalDate.now().year - 1)
+        set(Calendar.MONTH, 1)
+        set(Calendar.DAY_OF_MONTH, 1)
+    }.timeInMillis
+
+    val today = Calendar.getInstance().apply {
+        set(Calendar.YEAR, LocalDate.now().year)
+        set(Calendar.MONTH, LocalDate.now().monthValue)
+        set(Calendar.DAY_OF_MONTH, LocalDate.now().dayOfMonth)
+    }.timeInMillis
+
+    return today - startDay
+}
+
+private fun getPaddingWeeks(): Int {
+    var startDay = LocalDate.of(LocalDate.now().year - 1, 1, 1)
+    val today = LocalDate.now()
+    var result = 0
+
+    while (startDay < today) {
+        if (startDay.dayOfWeek != DayOfWeek.SUNDAY) result += 1
+        startDay = startDay.plusMonths(1L)
+    }
+
+    return result
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -74,7 +74,6 @@ fun CalendarLazyColumn(
         calendar.forEach { slice ->
             items(
                 items = calendarSetToCalendarDatesList(slice),
-                key = { week -> week.first { day -> day.dayType != DayType.PADDING }.date }
             ) { week ->
                 val firstOfYear = LocalDate.of(slice.startDate.year, 1, 1)
                 val startDate = week.first { day -> day.dayType != DayType.PADDING }.date
@@ -104,7 +103,7 @@ fun CalendarLazyColumn(
     }
 
     with(listState) {
-        InitScroll(clickedDay = clickedDay)
+        InitScroll()
 
         ShouldNextScroll {
             viewModel.fetchNextCalendarSet()


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve #349 
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- LazyColumn의 items의 key값 제거 
  - 같은 item을 다시 로드할 때 성능의 차이가 있을 수 있음
  - 하지만 한 item의 단위를 줄이는 리팩토링이 있었기 때문에 위 경우를 극복
- 중복된 날짜 중 하나를 클릭하면 나머지 하나도 클릭됨
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/144270956-fc63b611-c0ab-4df8-be12-a2cc93c529d8.png" width=350 />

