### PR TITLE
연달력 년도 표시로직 수정

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -72,16 +72,13 @@ fun CalendarLazyColumn(
             .fillMaxHeight()
     ) {
         calendar.forEach { slice ->
-            items(
-                items = calendarSetToCalendarDatesList(slice, viewModel.schedules.value),
-            ) { week ->
-                val firstOfYear = LocalDate.of(slice.startDate.year, 1, 1)
+            items(items = calendarSetToCalendarDatesList(slice, viewModel.schedules.value)) { week ->
                 val startDate = week.first { day -> day.dayType != DayType.PADDING }.date
                 val endDate = week.last { day -> day.dayType != DayType.PADDING }.date
+                val firstOfYear = LocalDate.of(endDate.year, 1, 1)
 
                 // 해가 갱신될 때마다 상단에 연표시
-                if (firstOfYear in startDate..endDate ||
-                    firstOfYear.plusYears(1L) in startDate..endDate)
+                if (firstOfYear in startDate..endDate)
                         Text(
                             text = "${startDate.year}년",
                             color = MaterialTheme.colors.primary,
@@ -103,7 +100,7 @@ fun CalendarLazyColumn(
     }
 
     with(listState) {
-        InitScroll()
+        InitScroll() // FIXME: listState의 initIndex 속성이 존재
 
         ShouldNextScroll {
             viewModel.fetchNextCalendarSet()


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #375
## Changes
<!-- - pr에서 변경된 내용 ex) 월단위 달력 디자인 변경 -->
- 기존: 1월 1일이 포함된 슬라이스의 첫 날짜의 년도를 표시
  - 기존 로직의 이유: 1주일 단위가 아니라 슬라이스 단위로 년도 표시 검사를 했음. 슬라이스가 몇 년에 걸친다면 1월 1일이 여러개이기 때문에 맨 앞 날짜의 년도로 표시했음.
- 변경: 1월 1일이 포함된 주의 1월 1일의 년도
  - 1월 1일이 여러개가 아니기 때문에 1월 1일의 년도로 표시하면 깔끔하게 해결 
## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
<img src="https://user-images.githubusercontent.com/55696672/145505800-92a53913-85aa-4475-9d75-a34760125a22.png" width=350 />
