### PR TITLE
연달력 시작화면 로직 리팩토링

### DIFF
--- a/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/utils/ComposeStateExtensions.kt
@@ -7,9 +7,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.util.*
 
-private const val DAY_OF_WEEK = 7
 
-private const val TIME_MILLIS_OF_DAY = 24 * 60 * 60 * 1000
 
 // 참고: https://ichi.pro/ko/jetpack-compose-ui-muhan-moglog-peiji-moglog-194681336448872
 @Composable
@@ -61,57 +59,4 @@ fun LazyListState.ShouldPrevScroll(
             if (should) { onLoadMore() }
         }
     }
-}
-
-@Composable
-fun LazyListState.InitScroll() {
-    val scroll = remember {
-        derivedStateOf {
-            with(layoutInfo) {
-                visibleItemsInfo.firstOrNull() ?: return@derivedStateOf 0
-
-                /** 이동해야할 스크롤 인덱스
-                 * 1. 인덱스 1당 1주일이 넘어간다.
-                 * 2. 달력의 빈 공간을 채워주기 위해 달이 넘어갈 때마다 비어있는 1주일이 생긴다.
-                 * (오늘 - 달력의 첫날) / 7 + 빈공간
-                  */
-                (getStartDayToToday() / DAY_OF_WEEK / TIME_MILLIS_OF_DAY).toInt() + getPaddingWeeks()
-            }
-        }
-    }
-
-    LaunchedEffect(scroll) {
-        snapshotFlow { scroll.value }.collect { index ->
-            if (index > 0) scrollToItem(index)
-        }
-    }
-}
-
-private fun getStartDayToToday(): Long {
-    val startDay = Calendar.getInstance().apply {
-        set(Calendar.YEAR, LocalDate.now().year - 1)
-        set(Calendar.MONTH, 1)
-        set(Calendar.DAY_OF_MONTH, 1)
-    }.timeInMillis
-
-    val today = Calendar.getInstance().apply {
-        set(Calendar.YEAR, LocalDate.now().year)
-        set(Calendar.MONTH, LocalDate.now().monthValue)
-        set(Calendar.DAY_OF_MONTH, LocalDate.now().dayOfMonth)
-    }.timeInMillis
-
-    return today - startDay
-}
-
-private fun getPaddingWeeks(): Int {
-    var startDay = LocalDate.of(LocalDate.now().year - 1, 1, 1)
-    val today = LocalDate.now()
-    var result = 0
-
-    while (startDay < today) {
-        if (startDay.dayOfWeek != DayOfWeek.SUNDAY) result += 1
-        startDay = startDay.plusMonths(1L)
-    }
-
-    return result
 }

--- a/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
+++ b/library/src/main/java/com/drunkenboys/ckscalendar/yearcalendar/composeView/CalendarLazyColumn.kt
@@ -27,13 +27,7 @@ import com.drunkenboys.ckscalendar.listener.OnDaySecondClickListener
 import com.drunkenboys.ckscalendar.utils.*
 import com.drunkenboys.ckscalendar.yearcalendar.CustomTheme
 import com.drunkenboys.ckscalendar.yearcalendar.YearCalendarViewModel
-import java.time.DayOfWeek
 import java.time.LocalDate
-import java.util.*
-
-private const val DAY_OF_WEEK = 7
-
-private const val TIME_MILLIS_OF_DAY = 24 * 60 * 60 * 1000
 
 @Composable
 fun CalendarLazyColumn(
@@ -42,7 +36,7 @@ fun CalendarLazyColumn(
     viewModel: YearCalendarViewModel
 ) {
     // RecyclerView의 상태를 관찰
-    val listState = rememberLazyListState((getStartDayToToday() / DAY_OF_WEEK / TIME_MILLIS_OF_DAY).toInt() + getPaddingWeeks())
+    val listState = rememberLazyListState(initialFirstVisibleItemIndex = viewModel.getInitScroll())
     val calendar by remember { viewModel.calendar }
     var clickedDay by rememberSaveable { mutableStateOf(LocalDate.now()) }
 
@@ -100,8 +94,6 @@ fun CalendarLazyColumn(
     }
 
     with(listState) {
-//        InitScroll() // FIXME: listState의 initIndex 속성이 존재
-
         ShouldNextScroll {
             viewModel.fetchNextCalendarSet()
         }
@@ -110,36 +102,6 @@ fun CalendarLazyColumn(
             viewModel.fetchPrevCalendarSet()
         }
     }
-}
-
-
-private fun getStartDayToToday(): Long {
-    val startDay = Calendar.getInstance().apply {
-        set(Calendar.YEAR, LocalDate.now().year - 1)
-        set(Calendar.MONTH, 1)
-        set(Calendar.DAY_OF_MONTH, 1)
-    }.timeInMillis
-
-    val today = Calendar.getInstance().apply {
-        set(Calendar.YEAR, LocalDate.now().year)
-        set(Calendar.MONTH, LocalDate.now().monthValue)
-        set(Calendar.DAY_OF_MONTH, LocalDate.now().dayOfMonth)
-    }.timeInMillis
-
-    return today - startDay
-}
-
-private fun getPaddingWeeks(): Int {
-    var startDay = LocalDate.of(LocalDate.now().year - 1, 1, 1)
-    val today = LocalDate.now()
-    var result = 0
-
-    while (startDay < today) {
-        if (startDay.dayOfWeek != DayOfWeek.SUNDAY) result += 1
-        startDay = startDay.plusMonths(1L)
-    }
-
-    return result
 }
 
 @Preview


### PR DESCRIPTION
## what is this pr
<!-- - pr에 관련된 issue number와 관련 문서 작성
- 해결한 issue -> Resolve: #2 -->
Resolve: #379 

## Changes
기본 캘린더에서 오늘 날짜를 보여주기 위한 스크롤 로직
- 기존: LazyListState의 확장함수를 만들어서 특정 조건일 때 특정 인덱스로 스크롤함.
- 변경: LazyListState를 초기화 할 때 초기 인덱스를 지정. 

## screenshot
<!-- - 변경된 내용과 관련된 스크린샷(보이지 않는 경우 생략) -->
변경 없음.
